### PR TITLE
Turbo game proc macro

### DIFF
--- a/bork-runner/src/lib.rs
+++ b/bork-runner/src/lib.rs
@@ -1,5 +1,8 @@
 use turbo::prelude::*;
+mod state;
+use state::*;
 
+#[derive(BorshDeserialize, BorshSerialize)]
 #[turbo::game]
 struct GameState {
     is_ready: bool,

--- a/bork-runner/src/lib.rs
+++ b/bork-runner/src/lib.rs
@@ -1,38 +1,39 @@
 mod state;
 use state::*;
+use turbo::{
+    canvas::{clear, rect, sprite, text},
+    input::{gamepad, pointer},
+    sys::{rand, tick},
+};
 
-// Define the game state initialization
-turbo::init! {
-    struct GameState {
-        is_ready: bool,
-        dog_x: f32,
-        dog_y: f32,
-        last_bork: u32,
-        bork_rate: u32,
-        bork_range: f32,
-        last_enemy_spawn: u32,
-        enemy_spawn_rate: u32,
-        is_jumping: bool,
-        energy: u32,
-        max_energy: u32,
-        recharge_rate: u32,
-        vel_y: f32,
-        borks: Vec<Bork>,
-        enemies: Vec<Enemy>,
-        powerups: Vec<Powerup>,
-        score: u32,
-        health: u32,
-        has_bat: bool,
-        last_bat_swing: u32,
-        can_fire_multiple_borks: bool,
-        last_game_over: u32,
-    } = {
-        Self::new()
-    }
+#[turbo::game]
+struct GameState {
+    is_ready: bool,
+    dog_x: f32,
+    dog_y: f32,
+    last_bork: u32,
+    bork_rate: u32,
+    bork_range: f32,
+    last_enemy_spawn: u32,
+    enemy_spawn_rate: u32,
+    is_jumping: bool,
+    energy: u32,
+    max_energy: u32,
+    recharge_rate: u32,
+    vel_y: f32,
+    borks: Vec<Bork>,
+    enemies: Vec<Enemy>,
+    powerups: Vec<Powerup>,
+    score: u32,
+    health: u32,
+    has_bat: bool,
+    last_bat_swing: u32,
+    can_fire_multiple_borks: bool,
+    last_game_over: u32,
 }
 
 impl GameState {
-    pub fn new() -> Self {
+    fn new() -> Self {
         Self {
             is_ready: false,
             dog_x: 20.0,
@@ -58,358 +59,347 @@ impl GameState {
             last_game_over: 0,
         }
     }
-}
+    fn update(&mut self) {
+        let t = tick() as u32;
 
-// Implement the game loop
-turbo::go!({
-    let mut state = GameState::load();
+        let gp = gamepad(0);
 
-    let t = tick() as u32;
-
-    let gp = gamepad(0);
-
-    if !state.is_ready && t >= state.enemy_spawn_rate {
-        state.is_ready = true;
-        state.is_jumping = true;
-        state.vel_y = -3.;
-    }
-
-    if state.last_game_over == 0 && state.is_ready {
-        // Bork!!!
-        if gp.start.just_released() || pointer().just_pressed() {
-            if t - state.last_bork >= state.bork_rate && state.energy > 0 {
-                state.borks.push(Bork::new(state.dog_x, state.dog_y));
-                state.last_bork = t;
-                state.energy -= 1;
-            }
+        if !self.is_ready && t >= self.enemy_spawn_rate {
+            self.is_ready = true;
+            self.is_jumping = true;
+            self.vel_y = -3.;
         }
 
-        // Swing bat
-        if gp.right.just_pressed() && state.has_bat {
-            // Bat melee attack logic
-            for enemy in state.enemies.iter_mut() {
-                if state.dog_x < enemy.x + ENEMY_WIDTH
-                    && state.dog_x + BAT_RANGE > enemy.x
-                    && state.dog_y < enemy.y + ENEMY_HEIGHT
-                    && state.dog_y + BAT_RANGE > enemy.y
-                {
-                    enemy.hits = enemy.max_hits; // Mark the enemy as hit by the bat
-                                                 // state.score += 15; // Increase score for hitting with the bat
+        if self.last_game_over == 0 && self.is_ready {
+            // Bork!!!
+            if gp.start.just_released() || pointer().just_pressed() {
+                if t - self.last_bork >= self.bork_rate && self.energy > 0 {
+                    self.borks.push(Bork::new(self.dog_x, self.dog_y));
+                    self.last_bork = t;
+                    self.energy -= 1;
                 }
             }
-            state.last_bat_swing = t;
-        }
 
-        // Physics and jump logic
-        if gp.up.just_pressed() && state.energy > 0 {
-            state.is_jumping = true;
-            if state.vel_y > -3.0 {
-                state.vel_y = (state.vel_y + -2.5).max(-3.0);
+            // Swing bat
+            if gp.right.just_pressed() && self.has_bat {
+                // Bat melee attack logic
+                for enemy in self.enemies.iter_mut() {
+                    if self.dog_x < enemy.x + ENEMY_WIDTH
+                        && self.dog_x + BAT_RANGE > enemy.x
+                        && self.dog_y < enemy.y + ENEMY_HEIGHT
+                        && self.dog_y + BAT_RANGE > enemy.y
+                    {
+                        enemy.hits = enemy.max_hits; // Mark the enemy as hit by the bat
+                                                     // self.score += 15; // Increase score for hitting with the bat
+                    }
+                }
+                self.last_bat_swing = t;
             }
-            state.energy -= 1;
-        } else if gp.down.just_pressed() {
-            state.is_jumping = true;
-            state.vel_y = (state.vel_y + 1.).min(6.);
-        }
-    }
 
-    // Apply gravity
-    if state.is_jumping {
-        state.dog_y += state.vel_y;
-        let floor = match state.health {
-            0 | 1 => 1.1,
-            2 => 0.85,
-            _ => 0.25,
-        };
-        if state.vel_y < floor {
-            state.vel_y += match state.health {
-                0 | 1 => 0.12,
-                2 => 0.11,
-                _ => 0.1,
+            // Physics and jump logic
+            if gp.up.just_pressed() && self.energy > 0 {
+                self.is_jumping = true;
+                if self.vel_y > -3.0 {
+                    self.vel_y = (self.vel_y + -2.5).max(-3.0);
+                }
+                self.energy -= 1;
+            } else if gp.down.just_pressed() {
+                self.is_jumping = true;
+                self.vel_y = (self.vel_y + 1.).min(6.);
+            }
+        }
+
+        // Apply gravity
+        if self.is_jumping {
+            self.dog_y += self.vel_y;
+            let floor = match self.health {
+                0 | 1 => 1.1,
+                2 => 0.85,
+                _ => 0.25,
             };
-        }
-        if state.last_game_over == 0 {
-            if state.dog_y > CANVAS_HEIGHT as f32 || state.dog_y < -DOGE_HEIGHT {
-                state.health = 0;
-                state.last_game_over = t;
+            if self.vel_y < floor {
+                self.vel_y += match self.health {
+                    0 | 1 => 0.12,
+                    2 => 0.11,
+                    _ => 0.1,
+                };
             }
-        }
-    }
-
-    // Increase energy
-    if state.last_game_over == 0 && t % state.recharge_rate == 0 && state.energy < state.max_energy
-    {
-        state.energy += 1;
-    }
-
-    // Update borks
-    state.borks.retain_mut(|bork| {
-        bork.update();
-        let mut collided = false;
-        for enemy in state.enemies.iter_mut() {
-            if bork.x < enemy.x + ENEMY_WIDTH
-                && bork.x + BORK_WIDTH > enemy.x
-                && bork.y < enemy.y + ENEMY_HEIGHT
-                && bork.y + BORK_HEIGHT > enemy.y
-            {
-                enemy.hits += 1; // Mark the enemy as hit by the bork
-                collided = true;
-            }
-        }
-        !collided && bork.x < state.dog_x + state.bork_range
-    });
-
-    // Spawn and update enemies
-    if t - state.last_enemy_spawn >= state.enemy_spawn_rate {
-        let vel_x = -1.0 + ((t / 10) as f32 * -0.01).max(-1.);
-        let modifier = (rand() % 200) as f32 / 100.;
-        let vel_x = vel_x * modifier;
-        state.enemies.push(Enemy::new(vel_x));
-        state.last_enemy_spawn = t;
-        if t > 60 * 1 && state.enemy_spawn_rate > 30 {
-            state.enemy_spawn_rate -= 2;
-        }
-    }
-    state.enemies.retain_mut(|enemy| {
-        enemy.update();
-        if state.dog_x < enemy.x + ENEMY_WIDTH
-            && state.dog_x + DOGE_WIDTH > enemy.x
-            && state.dog_y < enemy.y + ENEMY_HEIGHT
-            && state.dog_y + DOGE_HEIGHT > enemy.y
-        {
-            if state.health > 0 {
-                state.health -= 1;
-            }
-            if state.health == 0 {
-                state.last_game_over = t;
-            }
-            enemy.hits += 1; // Mark the enemy as hit
-        }
-        if enemy.hits >= enemy.max_hits {
-            state.score += 10;
-            return false;
-        }
-        enemy.x > -ENEMY_WIDTH
-    });
-
-    // Spawning powerups
-    if state.is_ready {
-        // if rand() % 100 < 10 { // Example probability for SpeedBoost
-        //     state.powerups.push(Powerup::new(CANVAS_WIDTH as f32, (rand() % CANVAS_HEIGHT) as f32, 0.0, 0.0, PowerupType::SpeedBoost));
-        // }
-        // if rand() % 100 < 5 { // Example probability for MultiBork
-        //     state.powerups.push(Powerup::new(CANVAS_WIDTH as f32, (rand() % CANVAS_HEIGHT) as f32, 0.0, 0.0, PowerupType::MultiBork));
-        // }
-        // if rand() % 100 < 3 { // Example probability for DoubleJump
-        //     let initial_y = (rand() % CANVAS_HEIGHT) as f32;
-        //     state.powerups.push(Powerup::new(CANVAS_WIDTH as f32, initial_y, 0.0, 2.0, PowerupType::DoubleJump));
-        // }
-        if rand() % 100 < 2 {
-            // Example probability for Bat
-            state.powerups.push(Powerup::new(
-                CANVAS_WIDTH as f32,
-                (rand() % CANVAS_HEIGHT) as f32,
-                0.0,
-                0.0,
-                PowerupType::Bat,
-            ));
-        }
-    }
-
-    // Powerup collection
-    state.powerups.retain_mut(|powerup| {
-        match powerup.powerup_type {
-            PowerupType::DoubleJump => {
-                // Sinusoidal movement
-                powerup.y += f32::sin(powerup.angle) * 2.0; // Adjust amplitude as needed
-                powerup.angle += 0.1; // Adjust frequency as needed
-                                      // Grant an extra jump
-                state.energy = 2;
-            }
-            PowerupType::SpeedBoost => {
-                // Simple leftward movement
-                powerup.x -= 2.0;
-                // Increase bork speed logic
-                for bork in state.borks.iter_mut() {
-                    bork.vel_x *= 1.5; // Example: Increase speed by 50%
+            if self.last_game_over == 0 {
+                if self.dog_y > CANVAS_HEIGHT as f32 || self.dog_y < -DOGE_HEIGHT {
+                    self.health = 0;
+                    self.last_game_over = t;
                 }
             }
-            PowerupType::MultiBork => {
-                // Diagonal movement
-                powerup.x -= 2.0;
-                powerup.y += powerup.vel_y;
-                // Enable multi-bork logic
-                state.can_fire_multiple_borks = true;
-            }
-            PowerupType::Bat => {
-                // Sinusoidal movement
-                powerup.x -= 2.0;
-                powerup.y += f32::sin(powerup.angle) * 5.0;
-                powerup.angle += 0.1;
-                // Enable bat melee attack
-                state.has_bat = true;
-            }
         }
-        if state.dog_x < powerup.x + POWERUP_WIDTH
-            && state.dog_x + DOGE_WIDTH > powerup.x
-            && state.dog_y < powerup.y + POWERUP_HEIGHT
-            && state.dog_y + DOGE_HEIGHT > powerup.y
+
+        // Increase energy
+        if self.last_game_over == 0 && t % self.recharge_rate == 0 && self.energy < self.max_energy
         {
-            if powerup.powerup_type == PowerupType::Bat && state.last_game_over == 0 {
-                state.score += 1;
+            self.energy += 1;
+        }
+
+        // Update borks
+        self.borks.retain_mut(|bork| {
+            bork.update();
+            let mut collided = false;
+            for enemy in self.enemies.iter_mut() {
+                if bork.x < enemy.x + ENEMY_WIDTH
+                    && bork.x + BORK_WIDTH > enemy.x
+                    && bork.y < enemy.y + ENEMY_HEIGHT
+                    && bork.y + BORK_HEIGHT > enemy.y
+                {
+                    enemy.hits += 1; // Mark the enemy as hit by the bork
+                    collided = true;
+                }
             }
-            false // Remove the powerup after applying its effect
+            !collided && bork.x < self.dog_x + self.bork_range
+        });
+
+        // Spawn and update enemies
+        if t - self.last_enemy_spawn >= self.enemy_spawn_rate {
+            let vel_x = -1.0 + ((t / 10) as f32 * -0.01).max(-1.);
+            let modifier = (rand() % 200) as f32 / 100.;
+            let vel_x = vel_x * modifier;
+            self.enemies.push(Enemy::new(vel_x));
+            self.last_enemy_spawn = t;
+            if t > 60 * 1 && self.enemy_spawn_rate > 30 {
+                self.enemy_spawn_rate -= 2;
+            }
+        }
+        self.enemies.retain_mut(|enemy| {
+            enemy.update();
+            if self.dog_x < enemy.x + ENEMY_WIDTH
+                && self.dog_x + DOGE_WIDTH > enemy.x
+                && self.dog_y < enemy.y + ENEMY_HEIGHT
+                && self.dog_y + DOGE_HEIGHT > enemy.y
+            {
+                if self.health > 0 {
+                    self.health -= 1;
+                }
+                if self.health == 0 {
+                    self.last_game_over = t;
+                }
+                enemy.hits += 1; // Mark the enemy as hit
+            }
+            if enemy.hits >= enemy.max_hits {
+                self.score += 10;
+                return false;
+            }
+            enemy.x > -ENEMY_WIDTH
+        });
+
+        // Spawning powerups
+        if self.is_ready {
+            // if rand() % 100 < 10 { // Example probability for SpeedBoost
+            //     self.powerups.push(Powerup::new(CANVAS_WIDTH as f32, (rand() % CANVAS_HEIGHT) as f32, 0.0, 0.0, PowerupType::SpeedBoost));
+            // }
+            // if rand() % 100 < 5 { // Example probability for MultiBork
+            //     self.powerups.push(Powerup::new(CANVAS_WIDTH as f32, (rand() % CANVAS_HEIGHT) as f32, 0.0, 0.0, PowerupType::MultiBork));
+            // }
+            // if rand() % 100 < 3 { // Example probability for DoubleJump
+            //     let initial_y = (rand() % CANVAS_HEIGHT) as f32;
+            //     self.powerups.push(Powerup::new(CANVAS_WIDTH as f32, initial_y, 0.0, 2.0, PowerupType::DoubleJump));
+            // }
+            if rand() % 100 < 2 {
+                // Example probability for Bat
+                self.powerups.push(Powerup::new(
+                    CANVAS_WIDTH as f32,
+                    (rand() % CANVAS_HEIGHT) as f32,
+                    0.0,
+                    0.0,
+                    PowerupType::Bat,
+                ));
+            }
+        }
+
+        // Powerup collection
+        self.powerups.retain_mut(|powerup| {
+            match powerup.powerup_type {
+                PowerupType::DoubleJump => {
+                    // Sinusoidal movement
+                    powerup.y += f32::sin(powerup.angle) * 2.0; // Adjust amplitude as needed
+                    powerup.angle += 0.1; // Adjust frequency as needed
+                                          // Grant an extra jump
+                    self.energy = 2;
+                }
+                PowerupType::SpeedBoost => {
+                    // Simple leftward movement
+                    powerup.x -= 2.0;
+                    // Increase bork speed logic
+                    for bork in self.borks.iter_mut() {
+                        bork.vel_x *= 1.5; // Example: Increase speed by 50%
+                    }
+                }
+                PowerupType::MultiBork => {
+                    // Diagonal movement
+                    powerup.x -= 2.0;
+                    powerup.y += powerup.vel_y;
+                    // Enable multi-bork logic
+                    self.can_fire_multiple_borks = true;
+                }
+                PowerupType::Bat => {
+                    // Sinusoidal movement
+                    powerup.x -= 2.0;
+                    powerup.y += f32::sin(powerup.angle) * 5.0;
+                    powerup.angle += 0.1;
+                    // Enable bat melee attack
+                    self.has_bat = true;
+                }
+            }
+            if self.dog_x < powerup.x + POWERUP_WIDTH
+                && self.dog_x + DOGE_WIDTH > powerup.x
+                && self.dog_y < powerup.y + POWERUP_HEIGHT
+                && self.dog_y + DOGE_HEIGHT > powerup.y
+            {
+                if powerup.powerup_type == PowerupType::Bat && self.last_game_over == 0 {
+                    self.score += 1;
+                }
+                false // Remove the powerup after applying its effect
+            } else {
+                true // Keep the powerup if it hasn't been collected
+            }
+        });
+
+        // Draw game elements
+        clear(0x00ffffff);
+
+        // Draw speed lines
+        let line_count = 15; // Number of speed lines
+        let max_speed = 25; // Maximum speed of the lines
+        let line_width = 128; // Screen width
+
+        for i in 0..line_count {
+            let speed = (i + 1) as u32 * max_speed / line_count; // Varying speeds for each line
+            let height = 1;
+            let y_position = ((i * 28) % 144) as i32; // Vertical position of each line
+            let x_position = (t * speed) as i32 % (512) as i32 - 20; // Moving from right to left
+            rect!(
+                w = line_width,
+                h = height,
+                x = 256 + -x_position,
+                y = y_position,
+                color = 0xffffff88
+            ); // Draw the line
+        }
+        if self.last_game_over == 0 {
+            let (balloons, doge) = match self.health {
+                0 | 1 => ("one_balloon", "doge_worried"),
+                2 => ("two_balloons", "doge_worried"),
+                _ => ("three_balloons", "doge_worried"),
+            };
+            let speed = if self.vel_y > 0. { 1.0 } else { 0.5 };
+            sprite!(balloons, x = self.dog_x - DOGE_WIDTH, y = self.dog_y - 16.,);
+            sprite!(
+                doge,
+                x = self.dog_x - DOGE_WIDTH,
+                y = self.dog_y,
+                animation_speed = speed,
+            );
         } else {
-            true // Keep the powerup if it hasn't been collected
+            sprite!(
+                "sad_doge",
+                x = self.dog_x - DOGE_WIDTH,
+                y = self.dog_y,
+                animation_speed = 2.0,
+            );
         }
-    });
+        for bork in self.borks.iter() {
+            bork.draw();
+        }
+        for enemy in self.enemies.iter() {
+            enemy.draw();
+        }
+        for powerup in self.powerups.iter() {
+            powerup.draw();
+        }
 
-    // Draw game elements
-    clear(0x00ffffff);
-    
-    
-    // Draw speed lines
-    let line_count = 15; // Number of speed lines
-    let max_speed = 25; // Maximum speed of the lines
-    let line_width = 128; // Screen width
-    
-    for i in 0..line_count {
-        let speed = (i + 1) as u32 * max_speed / line_count; // Varying speeds for each line
-        let height = 1;
-        let y_position = ((i * 28) % 144) as i32; // Vertical position of each line
-        let x_position = (t * speed) as i32 % (512) as i32 - 20; // Moving from right to left
-        rect!(
-            w = line_width,
-            h = height,
-            x = 256 + -x_position,
-            y = y_position,
-            color = 0xffffff88
-        ); // Draw the line
-    }
-    if state.last_game_over == 0 {
-        let (balloons, doge) = match state.health {
-            0 | 1 => ("one_balloon", "doge_worried"),
-            2 => ("two_balloons", "doge_worried"),
-            _ => ("three_balloons", "doge_worried"),
+        // Display health and score
+        rect!(w = 256, h = 24, color = 0xffffffaa);
+        let seconds = if self.last_game_over > 0 {
+            self.last_game_over
+        } else {
+            t
+        } / 60;
+        let minutes = seconds / 60;
+        let seconds = seconds % 60;
+        let mmss = &format!("{:02}:{:02}", minutes, seconds);
+        text!("time", x = 118, y = 3, color = 0xff0000ff, font = "small");
+        text!(mmss, x = 108, y = 9, font = "large", color = 0x000000aa);
+        text!(mmss, x = 108, y = 8, font = "large", color = 0x000000ff);
+
+        text!(
+            "BORK points",
+            x = 190,
+            y = 3,
+            color = 0x000000ff,
+            font = "small"
+        );
+        text!("${:06}", self.score; x = 190, y = 9, font = "large", color = 0x000000aa);
+        text!("${:06}", self.score; x = 190, y = 8, font = "large", color = 0x000000ff);
+
+        sprite!("energy", x = 4, y = 5);
+        let energy_color = match self.energy as f32 / self.max_energy as f32 {
+            n if n <= 0.25 => 0xff0000ff,
+            n if n <= 0.75 => 0xec8915ff,
+            _ => 0x00a0ffff,
         };
-        let speed = if state.vel_y > 0. { 1.0 } else { 0.5 };
-        sprite!(
-            balloons,
-            x = state.dog_x - DOGE_WIDTH,
-            y = state.dog_y - 16.,
+        text!("energy", x = 20, y = 3, color = 0x000000ff, font = "small");
+        rect!(
+            w = 4 * self.energy,
+            h = 6,
+            color = energy_color,
+            x = 18,
+            y = 10
         );
-        sprite!(
-            doge,
-            x = state.dog_x - DOGE_WIDTH,
-            y = state.dog_y,
-            animation_speed = speed,
-        );
-    } else {
-        sprite!(
-            "sad_doge",
-            x = state.dog_x - DOGE_WIDTH,
-            y = state.dog_y,
-            animation_speed = 2.0,
-        );
-    }
-    for bork in state.borks.iter() {
-        bork.draw();
-    }
-    for enemy in state.enemies.iter() {
-        enemy.draw();
-    }
-    for powerup in state.powerups.iter() {
-        powerup.draw();
-    }
 
-    // Display health and score
-    rect!(w = 256, h = 24, color = 0xffffffaa);
-    let seconds = if state.last_game_over > 0 {
-        state.last_game_over
-    } else {
-        t
-    } / 60;
-    let minutes = seconds / 60;
-    let seconds = seconds % 60;
-    let mmss = &format!("{:02}:{:02}", minutes, seconds);
-    text!("time", x = 118, y = 3, color = 0xff0000ff, font = "small");
-    text!(mmss, x = 108, y = 9, font = "large", color = 0x000000aa);
-    text!(mmss, x = 108, y = 8, font = "large", color = 0x000000ff);
+        if t < (60 / 2) {
+            text!("3", x = 124, y = 64, font = "large", color = 0x000000ff);
+        } else if t < (120 / 2) {
+            text!("2", x = 124, y = 64, font = "large", color = 0x000000ff);
+        } else if t < (180 / 2) {
+            text!("1", x = 124, y = 64, font = "large", color = 0x000000ff);
+        } else if t < (240 / 2) {
+            text!("GO!", x = 118, y = 64, font = "large", color = 0x000000ff);
+        }
 
-    text!(
-        "BORK points",
-        x = 190,
-        y = 3,
-        color = 0x000000ff,
-        font = "small"
-    );
-    text!("${:06}", state.score; x = 190, y = 9, font = "large", color = 0x000000aa);
-    text!("${:06}", state.score; x = 190, y = 8, font = "large", color = 0x000000ff);
-
-    sprite!("energy", x = 4, y = 5);
-    let energy_color = match state.energy as f32 / state.max_energy as f32 {
-        n if n <= 0.25 => 0xff0000ff,
-        n if n <= 0.75 => 0xec8915ff,
-        _ => 0x00a0ffff,
-    };
-    text!("energy", x = 20, y = 3, color = 0x000000ff, font = "small");
-    rect!(
-        w = 4 * state.energy,
-        h = 6,
-        color = energy_color,
-        x = 18,
-        y = 10
-    );
-
-    if t < (60 / 2) {
-        text!("3", x = 124, y = 64, font = "large", color = 0x000000ff);
-    } else if t < (120 / 2) {
-        text!("2", x = 124, y = 64, font = "large", color = 0x000000ff);
-    } else if t < (180 / 2) {
-        text!("1", x = 124, y = 64, font = "large", color = 0x000000ff);
-    } else if t < (240 / 2) {
-        text!("GO!", x = 118, y = 64, font = "large", color = 0x000000ff);
-    }
-
-    // Game over logic
-    if state.last_game_over > 0 {
-        text!(
-            "GAME OVER",
-            x = 90,
-            y = 73,
-            font = "large",
-            color = 0x000000aa
-        );
-        text!(
-            "GAME OVER",
-            x = 90,
-            y = 72,
-            font = "large",
-            color = 0xff0000ff
-        );
-        // Add logic to restart or exit the game
-        if t - state.last_game_over > 60 {
-            if t / 2 % 32 < 16 {
-                text!(
-                    "- press start -",
-                    x = 88,
-                    y = 84,
-                    font = "medium",
-                    color = 0x000000aa
-                );
-                text!(
-                    "- press start -",
-                    x = 88,
-                    y = 83,
-                    font = "medium",
-                    color = 0x000000ff
-                );
-            }
-            if gp.start.just_pressed() || pointer().just_pressed() {
-                state = GameState::new()
+        // Game over logic
+        if self.last_game_over > 0 {
+            text!(
+                "GAME OVER",
+                x = 90,
+                y = 73,
+                font = "large",
+                color = 0x000000aa
+            );
+            text!(
+                "GAME OVER",
+                x = 90,
+                y = 72,
+                font = "large",
+                color = 0xff0000ff
+            );
+            // Add logic to restart or exit the game
+            if t - self.last_game_over > 60 {
+                if t / 2 % 32 < 16 {
+                    text!(
+                        "- press start -",
+                        x = 88,
+                        y = 84,
+                        font = "medium",
+                        color = 0x000000aa
+                    );
+                    text!(
+                        "- press start -",
+                        x = 88,
+                        y = 83,
+                        font = "medium",
+                        color = 0x000000ff
+                    );
+                }
+                if gp.start.just_pressed() || pointer().just_pressed() {
+                    GameState::new();
+                }
             }
         }
     }
-
-    state.save();
-});
+}

--- a/bork-runner/src/lib.rs
+++ b/bork-runner/src/lib.rs
@@ -1,10 +1,4 @@
-mod state;
-use state::*;
-use turbo::{
-    canvas::{clear, rect, sprite, text},
-    input::{gamepad, pointer},
-    sys::{rand, tick},
-};
+use turbo::prelude::*;
 
 #[turbo::game]
 struct GameState {

--- a/card-search/Cargo.toml
+++ b/card-search/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [dependencies]
 borsh = "1.5.7"
 turbo = { version = "^3.1.0", package = "turbo-genesis-sdk" }
-turbo-genesis-sdk = "3.1.1"
 
 [lib]
 crate-type = ["cdylib"]

--- a/card-search/Cargo.toml
+++ b/card-search/Cargo.toml
@@ -4,7 +4,9 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-turbo = { version = "^3.0.0", package = "turbo-genesis-sdk" }
+borsh = "1.5.7"
+turbo = { version = "^3.1.0", package = "turbo-genesis-sdk" }
+turbo-genesis-sdk = "3.1.1"
 
 [lib]
 crate-type = ["cdylib"]

--- a/card-search/src/lib.rs
+++ b/card-search/src/lib.rs
@@ -1,10 +1,4 @@
-use turbo::{
-    canvas::{camera, rect},
-    input::{gamepad, pointer},
-    log, os,
-    sys::time,
-};
-use turbo_genesis_sdk::prelude::{BorshDeserialize, BorshSerialize};
+use turbo::{os::client::watch_file, prelude::*};
 
 const BOARD_SIZE: u8 = 16;
 const CARD_SIZE: (u8, u8) = (16, 24);
@@ -15,6 +9,7 @@ const CARD_COLOR: u32 = 0x1E3A8Aff;
 const CARD_HIGHLIGHT: u32 = 0x2563EBff;
 const CARD_FLIPPED_COLOR: u32 = 0xF0F0F0ff;
 
+#[derive(BorshDeserialize, BorshSerialize)]
 #[turbo::game]
 struct GameState {
     board: Option<Board>,

--- a/card-search/src/lib.rs
+++ b/card-search/src/lib.rs
@@ -1,4 +1,10 @@
-use os::client::watch_file;
+use turbo::{
+    canvas::{camera, rect},
+    input::{gamepad, pointer},
+    log, os,
+    sys::time,
+};
+use turbo_genesis_sdk::prelude::{BorshDeserialize, BorshSerialize};
 
 const BOARD_SIZE: u8 = 16;
 const CARD_SIZE: (u8, u8) = (16, 24);
@@ -9,80 +15,74 @@ const CARD_COLOR: u32 = 0x1E3A8Aff;
 const CARD_HIGHLIGHT: u32 = 0x2563EBff;
 const CARD_FLIPPED_COLOR: u32 = 0xF0F0F0ff;
 
-turbo::init! {
-    struct GameState {
-        board: Option<Board>,
-    } = {
-        Self {
-            board: None,
-        }
-    }
+#[turbo::game]
+struct GameState {
+    board: Option<Board>,
 }
-
-turbo::go!({
-    let mut state = GameState::load();
-    //draw the background
-    draw_checkerboard();
-
-
-    let pointer = pointer(); 
-    let (x, y) = pointer.xy(); 
-
-    if gamepad(0).a.just_pressed() {
-        let c = camera::xy();
-        log!("{:?}", c);
-        camera::reset();
+impl GameState {
+    fn new() -> Self {
+        Self { board: None }
     }
+    fn update(&mut self) {
+        //draw the background
+        draw_checkerboard();
 
-    state.board = watch_file("card_search", "board")
-        .data
-        .and_then(|file| Board::try_from_slice(&file.contents).ok());
+        let pointer = pointer();
+        let (x, y) = pointer.xy();
 
-    match &mut state.board {
-        None => {}
-        Some(b) => {
-            let crown_found = is_crown_found(&b);
-            for card in &mut b.cards {
-                card.draw((x, y));
-                if pointer.just_pressed() && !crown_found {
-                    card.on_click((x, y));
+        if gamepad(0).a.just_pressed() {
+            let c = camera::xy();
+            log!("{:?}", c);
+            camera::reset();
+        }
+
+        self.board = watch_file("card_search", "board")
+            .data
+            .and_then(|file| Board::try_from_slice(&file.contents).ok());
+
+        match &mut self.board {
+            None => {}
+            Some(b) => {
+                let crown_found = is_crown_found(&b);
+                for card in &mut b.cards {
+                    card.draw((x, y));
+                    if pointer.just_pressed() && !crown_found {
+                        card.on_click((x, y));
+                    }
                 }
             }
         }
-    }
 
-
-    //Watch for alerts
-    if let Some(event) = os::client::watch_events("card_search", Some("alert")).data {
-        //Display an alert banner for notifications that are < 10s old
-        let duration = 10_000;
-        let millis_since_event = time::now() - event.created_at as u64 * 1000;
-        if millis_since_event < duration {
-            if let Ok(msg) = std::str::from_utf8(&event.data) {
-                let txt = format!("User {}", msg);
-                centered_text(&txt, 200, CARD_FLIPPED_COLOR);
-                centered_text("Found the crown", 210, CARD_FLIPPED_COLOR);
+        //Watch for alerts
+        if let Some(event) = os::client::watch_events("card_search", Some("alert")).data {
+            //Display an alert banner for notifications that are < 10s old
+            let duration = 10_000;
+            let millis_since_event = time::now() - event.created_at as u64 * 1000;
+            if millis_since_event < duration {
+                if let Ok(msg) = std::str::from_utf8(&event.data) {
+                    let txt = format!("User {}", msg);
+                    centered_text(&txt, 200, CARD_FLIPPED_COLOR);
+                    centered_text("Found the crown", 210, CARD_FLIPPED_COLOR);
+                }
             }
         }
-    }
-    //if you don't have a board (should never happen) or the crown is found
-    //then show text saying press Z to start a new game
-    if state.board.is_none() || state.board.as_ref().map_or(false, is_crown_found) {
-        //show text to press z to get a new game
-        centered_text("Press Z", 10, CARD_FLIPPED_COLOR);
-        centered_text("To Start New Game", 20, CARD_FLIPPED_COLOR);
-        let gp = gamepad(0);
-        if gp.a.just_pressed() {
-            //if you press Z (gamepad a), call the generate_board function
-            os::client::exec("card_search", "generate_board", &[]);
+        //if you don't have a board (should never happen) or the crown is found
+        //then show text saying press Z to start a new game
+        if self.board.is_none() || self.board.as_ref().map_or(false, is_crown_found) {
+            //show text to press z to get a new game
+            centered_text("Press Z", 10, CARD_FLIPPED_COLOR);
+            centered_text("To Start New Game", 20, CARD_FLIPPED_COLOR);
+            let gp = gamepad(0);
+            if gp.a.just_pressed() {
+                //if you press Z (gamepad a), call the generate_board function
+                os::client::exec("card_search", "generate_board", &[]);
+            }
+            //if crown isn't found, then show this text instead
+        } else {
+            centered_text("Find the Crown!", 10, CARD_FLIPPED_COLOR);
         }
-        //if crown isn't found, then show this text instead
-    } else {
-        centered_text("Find the Crown!", 10, CARD_FLIPPED_COLOR);
     }
-
-    state.save();
-});
+}
 
 fn is_crown_found(board: &Board) -> bool {
     for c in &board.cards {

--- a/counter-demo/Cargo.toml
+++ b/counter-demo/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 turbo = { version = "^3.1.0", package = "turbo-genesis-sdk" }
-turbo-genesis-sdk = "3.1.1"
+
 
 [lib]
 crate-type = ["cdylib"]

--- a/counter-demo/Cargo.toml
+++ b/counter-demo/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 turbo = { version = "^3.1.0", package = "turbo-genesis-sdk" }
+turbo-genesis-sdk = "3.1.1"
 
 [lib]
 crate-type = ["cdylib"]

--- a/counter-demo/Cargo.toml
+++ b/counter-demo/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-turbo = { version = "^3.0.0", package = "turbo-genesis-sdk" }
+turbo = { version = "^3.1.0", package = "turbo-genesis-sdk" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/counter-demo/src/lib.rs
+++ b/counter-demo/src/lib.rs
@@ -1,4 +1,8 @@
-use turbo::borsh::*;
+use turbo::{
+    canvas::{clear, rect, text},
+    os,
+};
+use turbo_genesis_sdk::prelude::BorshDeserialize;
 
 //colors
 const BACKGROUND_COLOR: u32 = 0x2B2B2Bff;
@@ -8,85 +12,88 @@ const RED_COLOR: u32 = 0xFF4040ff;
 const BUTTON_COLOR: u32 = 0x4169E1ff;
 const BUTTON_TEXT_COLOR: u32 = 0xF0F8FFff;
 
-turbo::go!({
-    clear(BACKGROUND_COLOR);
-    //draw the minus button
-    let (w, h) = (30, 20);
-    let (x, y) = (20, 180);
-    draw_button(w, h, x, y);
-    text!(
-        "-",
-        x = 32,
-        y = 187,
-        font = "large",
-        color = BUTTON_TEXT_COLOR
-    );
+#[turbo::game]
+struct GameState {}
+impl GameState {
+    fn new() -> Self {}
+    fn update(&mut self) {
+        clear(BACKGROUND_COLOR);
+        //draw the minus button
+        let (w, h) = (30, 20);
+        let (x, y) = (20, 180);
+        draw_button(w, h, x, y);
+        text!(
+            "-",
+            x = 32,
+            y = 187,
+            font = "large",
+            color = BUTTON_TEXT_COLOR
+        );
 
+        // Store the pointer struct once
+        let pointer = pointer();
 
-    // Store the pointer struct once
-    let pointer = pointer();
+        // subtract 1 if minus button is clicked
+        if pointer.just_pressed() && pointer.intersects(x, y, w, h) {
+            let delta: i32 = -1;
+            let bytes = delta.to_le_bytes();
+            os::client::exec("counter", "increment_counter", &bytes);
+        }
 
-    // subtract 1 if minus button is clicked
-    if pointer.just_pressed() && pointer.intersects(x, y, w, h) {
-        let delta: i32 = -1;
-        let bytes = delta.to_le_bytes();
-        os::client::exec("counter", "increment_counter", &bytes);
+        // draw the plus button
+        let (x, y) = (82, 180);
+        draw_button(w, h, x, y);
+        text!(
+            "+",
+            x = 94,
+            y = 187,
+            font = "large",
+            color = BUTTON_TEXT_COLOR
+        );
+
+        // add 1 if plus button is clicked
+        if pointer.just_pressed() && pointer.intersects(x, y, w, h) {
+            let delta: i32 = 1;
+            let bytes = delta.to_le_bytes();
+            os::client::exec("counter", "increment_counter", &bytes);
+        }
+
+        //draw texts on top of screen
+        let userid = os::client::user_id();
+        if let Some(ref id) = userid {
+            let truncated = if id.len() > 8 {
+                format!("{}...", &id[..8])
+            } else {
+                id.to_string()
+            };
+            let txt = format!("User: {}", truncated);
+            //draw the user ID, truncated for only 8 digits
+            text!(&txt, x = 10, y = 10, font = "medium", color = WHITE_COLOR);
+
+            //draw the user's saved counter
+            let filepath = format!("users/{}", id);
+            //read the number from the server using watch_file
+            let num = os::client::watch_file("counter", &filepath)
+                .data
+                .and_then(|file| i32::try_from_slice(&file.contents).ok())
+                .unwrap_or(0); //set to 0 if the file doesn't exist
+            let txt = format!("Your Count: {}", num);
+            text!(&txt, x = 10, y = 25, font = "medium", color = WHITE_COLOR);
+
+            //draw the global count
+            let filepath = "global_count";
+            //read the number from the server using watch_file
+            let num = os::client::watch_file("counter", &filepath)
+                .data
+                .and_then(|file| i32::try_from_slice(&file.contents).ok())
+                .unwrap_or(0); //set to 0 if the file doesn't exist
+            let txt = format!("Global Count: {}", num);
+
+            let color = if num < 0 { RED_COLOR } else { GREEN_COLOR };
+            text!(&txt, x = 10, y = 40, font = "medium", color = color);
+        }
     }
-
-    // draw the plus button
-    let (x, y) = (82, 180);
-    draw_button(w, h, x, y);
-    text!(
-        "+",
-        x = 94,
-        y = 187,
-        font = "large",
-        color = BUTTON_TEXT_COLOR
-    );
-
-    // add 1 if plus button is clicked
-    if pointer.just_pressed() && pointer.intersects(x, y, w, h) {
-        let delta: i32 = 1;
-        let bytes = delta.to_le_bytes();
-        os::client::exec("counter", "increment_counter", &bytes);
-    }
-
-
-    //draw texts on top of screen
-    let userid = os::client::user_id();
-    if let Some(ref id) = userid {
-        let truncated = if id.len() > 8 {
-            format!("{}...", &id[..8])
-        } else {
-            id.to_string()
-        };
-        let txt = format!("User: {}", truncated);
-        //draw the user ID, truncated for only 8 digits
-        text!(&txt, x = 10, y = 10, font = "medium", color = WHITE_COLOR);
-
-        //draw the user's saved counter
-        let filepath = format!("users/{}", id);
-        //read the number from the server using watch_file
-        let num = os::client::watch_file("counter", &filepath)
-            .data
-            .and_then(|file| i32::try_from_slice(&file.contents).ok())
-            .unwrap_or(0); //set to 0 if the file doesn't exist
-        let txt = format!("Your Count: {}", num);
-        text!(&txt, x = 10, y = 25, font = "medium", color = WHITE_COLOR);
-
-        //draw the global count
-        let filepath = "global_count";
-        //read the number from the server using watch_file
-        let num = os::client::watch_file("counter", &filepath)
-            .data
-            .and_then(|file| i32::try_from_slice(&file.contents).ok())
-            .unwrap_or(0); //set to 0 if the file doesn't exist
-        let txt = format!("Global Count: {}", num);
-
-        let color = if num < 0 { RED_COLOR } else { GREEN_COLOR };
-        text!(&txt, x = 10, y = 40, font = "medium", color = color);
-    }
-});
+}
 
 fn draw_button(w: i32, h: i32, x: i32, y: i32) {
     rect!(

--- a/counter-demo/src/lib.rs
+++ b/counter-demo/src/lib.rs
@@ -1,8 +1,4 @@
-use turbo::{
-    canvas::{clear, rect, text},
-    os,
-};
-use turbo_genesis_sdk::prelude::BorshDeserialize;
+use turbo::prelude::*;
 
 //colors
 const BACKGROUND_COLOR: u32 = 0x2B2B2Bff;
@@ -12,10 +8,13 @@ const RED_COLOR: u32 = 0xFF4040ff;
 const BUTTON_COLOR: u32 = 0x4169E1ff;
 const BUTTON_TEXT_COLOR: u32 = 0xF0F8FFff;
 
+#[derive(BorshDeserialize, BorshSerialize)]
 #[turbo::game]
 struct GameState {}
 impl GameState {
-    fn new() -> Self {}
+    fn new() -> Self {
+        Self {}
+    }
     fn update(&mut self) {
         clear(BACKGROUND_COLOR);
         //draw the minus button

--- a/game-of-life/Cargo.toml
+++ b/game-of-life/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-turbo = { version = "^3.0.0", package = "turbo-genesis-sdk" }
+turbo = { version = "^3.1.0", package = "turbo-genesis-sdk" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/game-of-life/src/lib.rs
+++ b/game-of-life/src/lib.rs
@@ -1,9 +1,18 @@
-turbo::init! {
-    struct GameState {
-        grid: Vec<Vec<bool>>,
-        next_grid: Vec<Vec<bool>>,
-        cell_size: u32,
-    } = {
+use turbo::{
+    canvas::{clear, rect},
+    input::{gamepad, pointer},
+    sys::rand,
+};
+
+#[turbo::game]
+struct GameState {
+    grid: Vec<Vec<bool>>,
+    next_grid: Vec<Vec<bool>>,
+    cell_size: u32,
+}
+
+impl GameState {
+    fn new() -> Self {
         let cell_size = 8; // Size of each cell in pixels
         let grid_size = 256 / cell_size; // Number of cells in each dimension
         Self {
@@ -12,64 +21,59 @@ turbo::init! {
             cell_size,
         }
     }
+    fn update(&mut self) {
+        if gamepad(0).start.just_pressed()
+            || gamepad(0).select.just_pressed()
+            || pointer().just_pressed()
+        {
+            // Randomize grid on A button press
+            for row in 0..self.grid.len() {
+                for col in 0..self.grid[row].len() {
+                    self.grid[row][col] = rand() % 2 == 0;
+                }
+            }
+        }
+
+        // Game logic
+        for y in 0..self.grid.len() {
+            for x in 0..self.grid[y].len() {
+                let alive_neighbours = count_alive_neighbours(&self.grid, x, y);
+                // Alive cell logic
+                if self.grid[y][x] {
+                    // An alive cell survives if it has exactly 2 or 3 alive neighbours, otherwise it dies
+                    self.next_grid[y][x] = alive_neighbours == 2 || alive_neighbours == 3;
+                } else {
+                    // A dead cell becomes alive if it has exactly 3 alive neighbours
+                    self.next_grid[y][x] = alive_neighbours == 3;
+                }
+            }
+        }
+
+        // Swap grids
+        let temp = self.grid.clone();
+        self.grid = self.next_grid.clone();
+        self.next_grid = temp;
+
+        // Drawing
+        clear(0x000000ff); // Clear screen with black
+
+        for y in 0..self.grid.len() {
+            for x in 0..self.grid[y].len() {
+                if self.grid[y][x] {
+                    let x_pos = x as i32 * self.cell_size as i32;
+                    let y_pos = y as i32 * self.cell_size as i32;
+                    rect!(
+                        x = x_pos,
+                        y = y_pos,
+                        w = self.cell_size,
+                        h = self.cell_size,
+                        color = 0xffffffff
+                    ); // Draw living cell
+                }
+            }
+        }
+    }
 }
-
-turbo::go!({
-    let mut state = GameState::load();
-
-    if gamepad(0).start.just_pressed()
-        || gamepad(0).select.just_pressed()
-        || pointer().just_pressed()
-    {
-        // Randomize grid on A button press
-        for row in 0..state.grid.len() {
-            for col in 0..state.grid[row].len() {
-                state.grid[row][col] = rand() % 2 == 0;
-            }
-        }
-    }
-
-    // Game logic
-    for y in 0..state.grid.len() {
-        for x in 0..state.grid[y].len() {
-            let alive_neighbours = count_alive_neighbours(&state.grid, x, y);
-            // Alive cell logic
-            if state.grid[y][x] {
-                // An alive cell survives if it has exactly 2 or 3 alive neighbours, otherwise it dies
-                state.next_grid[y][x] = alive_neighbours == 2 || alive_neighbours == 3;
-            } else {
-                // A dead cell becomes alive if it has exactly 3 alive neighbours
-                state.next_grid[y][x] = alive_neighbours == 3;
-            }
-        }
-    }
-
-    // Swap grids
-    let temp = state.grid;
-    state.grid = state.next_grid;
-    state.next_grid = temp;
-
-    // Drawing
-    clear(0x000000ff); // Clear screen with black
-
-    for y in 0..state.grid.len() {
-        for x in 0..state.grid[y].len() {
-            if state.grid[y][x] {
-                let x_pos = x as i32 * state.cell_size as i32;
-                let y_pos = y as i32 * state.cell_size as i32;
-                rect!(
-                    x = x_pos,
-                    y = y_pos,
-                    w = state.cell_size,
-                    h = state.cell_size,
-                    color = 0xffffffff
-                ); // Draw living cell
-            }
-        }
-    }
-
-    state.save();
-});
 
 // Helper function to count alive neighbours
 fn count_alive_neighbours(grid: &Vec<Vec<bool>>, x: usize, y: usize) -> i32 {

--- a/game-of-life/src/lib.rs
+++ b/game-of-life/src/lib.rs
@@ -1,9 +1,6 @@
-use turbo::{
-    canvas::{clear, rect},
-    input::{gamepad, pointer},
-    sys::rand,
-};
+use turbo::prelude::*;
 
+#[derive(BorshDeserialize, BorshSerialize)]
 #[turbo::game]
 struct GameState {
     grid: Vec<Vec<bool>>,

--- a/pancake-cat/Cargo.toml
+++ b/pancake-cat/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-turbo = { version = "^3.0.0", package = "turbo-genesis-sdk" }
+turbo = { version = "^3.1.0", package = "turbo-genesis-sdk" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/pancake-cat/src/lib.rs
+++ b/pancake-cat/src/lib.rs
@@ -1,5 +1,6 @@
-use turbo::{canvas::*, input::gamepad, sys::rand};
+use turbo::prelude::*;
 
+#[derive(BorshDeserialize, BorshSerialize)]
 struct Pancake {
     x: f32,
     y: f32,
@@ -7,6 +8,7 @@ struct Pancake {
     radius: f32,
 }
 
+#[derive(BorshDeserialize, BorshSerialize)]
 #[turbo::game]
 struct GameState {
     frame: u32,

--- a/pancake-cat/src/lib.rs
+++ b/pancake-cat/src/lib.rs
@@ -1,147 +1,149 @@
-turbo::init! {
-    struct GameState {
-        frame: u32,
-        last_munch_at: u32,
-        cat_x: f32,
-        cat_y: f32,
-        cat_r: f32,
-        pancakes: Vec<struct Pancake {
-            x: f32,
-            y: f32,
-            vel: f32,
-            radius: f32,
-        }>,
-        score: u32,
-    } = Self {
-        frame: 0,
-        last_munch_at: 0,
-        cat_x: 128.0,
-        cat_y: 112.0,
-        cat_r: 8.0,
-        pancakes: vec![],
-        score: 0,
-    }
+use turbo::{canvas::*, input::gamepad, sys::rand};
+
+struct Pancake {
+    x: f32,
+    y: f32,
+    vel: f32,
+    radius: f32,
 }
 
-// Implement the game loop using the turbo::go! macro
-turbo::go!({
-    // Load the game state
-    let mut state = GameState::load();
+#[turbo::game]
+struct GameState {
+    frame: u32,
+    last_munch_at: u32,
+    cat_x: f32,
+    cat_y: f32,
+    cat_r: f32,
+    pancakes: Vec<Pancake>,
+    score: u32,
+}
 
-    // Handle user input
-    if gamepad(0).left.pressed() {
-        state.cat_x -= 2.;
-    }
-    if gamepad(0).right.pressed() {
-        state.cat_x += 2.;
-    }
-
-    // Generate new pancakes at random intervals
-    if rand() % 64 == 0 {
-        // Create a new pancake with random attributes
-        let pancake = Pancake {
-            x: (rand() % 256) as f32,
-            y: 0.0,
-            vel: (rand() % 3 + 1) as f32,
-            radius: (rand() % 10 + 5) as f32,
-        };
-        state.pancakes.push(pancake);
-    }
-
-    // Update pancake positions and check for collisions with the cat
-    let cat_center = (state.cat_x + state.cat_r, state.cat_y + state.cat_r);
-    state.pancakes.retain_mut(|pancake| {
-        pancake.y += pancake.vel;
-
-        // Check for collision with the cat
-        let pancake_center = (pancake.x + pancake.radius, pancake.y + pancake.radius);
-
-        // Calculate the distance between the cat and the pancake
-        let dx = cat_center.0 - pancake_center.0;
-        let dy = cat_center.1 - pancake_center.1;
-
-        let distance = (dx * dx + dy * dy).sqrt();
-        let radii_sum = state.cat_r + pancake.radius;
-        let radii_diff = (state.cat_r - pancake.radius).abs();
-
-        if radii_diff <= distance && distance <= radii_sum {
-            // Cat caught the pancake
-            state.score += 1;
-            state.last_munch_at = state.frame;
-            false // Remove the pancake from the game
-        } else if pancake.y < 144. + (pancake.radius * 2.) {
-            true // Keep the pancake in the game if it's within the screen
-        } else {
-            false // Remove the pancake if it's off-screen
-        }
-    });
-
-    // Set the background color
-    clear(0x00ffffff);
-
-    // Draw a tiled background of moving sprites
-    let frame = (state.frame as i32) / 2;
-    for col in 0..9 {
-        for row in 0..6 {
-            let x = col * 32;
-            let y = row * 32;
-            let x = ((x + frame) % (272 + 16)) - 32;
-            let y = ((y + frame) % (144 + 16)) - 24;
-            sprite!("heart", x = x, y = y);
+impl GameState {
+    fn new() -> Self {
+        Self {
+            frame: 0,
+            last_munch_at: 0,
+            cat_x: 128.0,
+            cat_y: 112.0,
+            cat_r: 8.0,
+            pancakes: vec![],
+            score: 0,
         }
     }
+    fn update(&mut self) {
+        if gamepad(0).left.pressed() {
+            self.cat_x -= 2.;
+        }
+        if gamepad(0).right.pressed() {
+            self.cat_x += 2.;
+        }
 
-    // Draw a speech bubble when the cat eats a pancake
-    if state.frame >= 64 && state.frame.saturating_sub(state.last_munch_at) <= 60 {
-        rect!(w = 30, h = 10, x = state.cat_x + 32.0, y = state.cat_y);
-        circ!(d = 10, x = state.cat_x + 28.0, y = state.cat_y);
-        rect!(w = 10, h = 5, x = state.cat_x + 28.0, y = state.cat_y + 5.0);
-        circ!(d = 10, x = state.cat_x + 56.0, y = state.cat_y);
-        text!(
-            "MUNCH!",
-            x = state.cat_x + 33.0,
-            y = state.cat_y + 3.0,
-            font = "small",
-            color = 0x000000ff
+        // Generate new pancakes at random intervals
+        if rand() % 64 == 0 {
+            // Create a new pancake with random attributes
+            let pancake = Pancake {
+                x: (rand() % 256) as f32,
+                y: 0.0,
+                vel: (rand() % 3 + 1) as f32,
+                radius: (rand() % 10 + 5) as f32,
+            };
+            self.pancakes.push(pancake);
+        }
+
+        // Update pancake positions and check for collisions with the cat
+        let cat_center = (self.cat_x + self.cat_r, self.cat_y + self.cat_r);
+        self.pancakes.retain_mut(|pancake| {
+            pancake.y += pancake.vel;
+
+            // Check for collision with the cat
+            let pancake_center = (pancake.x + pancake.radius, pancake.y + pancake.radius);
+
+            // Calculate the distance between the cat and the pancake
+            let dx = cat_center.0 - pancake_center.0;
+            let dy = cat_center.1 - pancake_center.1;
+
+            let distance = (dx * dx + dy * dy).sqrt();
+            let radii_sum = self.cat_r + pancake.radius;
+            let radii_diff = (self.cat_r - pancake.radius).abs();
+
+            if radii_diff <= distance && distance <= radii_sum {
+                // Cat caught the pancake
+                self.score += 1;
+                self.last_munch_at = self.frame;
+                false // Remove the pancake from the game
+            } else if pancake.y < 144. + (pancake.radius * 2.) {
+                true // Keep the pancake in the game if it's within the screen
+            } else {
+                false // Remove the pancake if it's off-screen
+            }
+        });
+
+        // Set the background color
+        clear(0x00ffffff);
+
+        // Draw a tiled background of moving sprites
+        let frame = (self.frame as i32) / 2;
+        for col in 0..9 {
+            for row in 0..6 {
+                let x = col * 32;
+                let y = row * 32;
+                let x = ((x + frame) % (272 + 16)) - 32;
+                let y = ((y + frame) % (144 + 16)) - 24;
+                sprite!("heart", x = x, y = y);
+            }
+        }
+
+        // Draw a speech bubble when the cat eats a pancake
+        if self.frame >= 64 && self.frame.saturating_sub(self.last_munch_at) <= 60 {
+            rect!(w = 30, h = 10, x = self.cat_x + 32.0, y = self.cat_y);
+            circ!(d = 10, x = self.cat_x + 28.0, y = self.cat_y);
+            rect!(w = 10, h = 5, x = self.cat_x + 28.0, y = self.cat_y + 5.0);
+            circ!(d = 10, x = self.cat_x + 56.0, y = self.cat_y);
+            text!(
+                "MUNCH!",
+                x = self.cat_x + 33.0,
+                y = self.cat_y + 3.0,
+                font = "small",
+                color = 0x000000ff
+            );
+        }
+
+        // Draw the cat
+        sprite!(
+            "munch_cat",
+            x = self.cat_x - self.cat_r,
+            y = self.cat_y - 16.0
         );
+
+        // Draw the falling pancakes
+        for pancake in &self.pancakes {
+            circ!(
+                x = pancake.x,
+                y = pancake.y + 1.0,
+                d = pancake.radius + 2.,
+                color = 0x000000aa
+            ); // Render the pancakes
+            circ!(
+                x = pancake.x,
+                y = pancake.y,
+                d = pancake.radius + 1.,
+                color = 0xf4d29cff
+            ); // Render the pancakes
+            circ!(
+                x = pancake.x,
+                y = pancake.y,
+                d = pancake.radius,
+                color = 0xdba463ff
+            ); // Render the pancakes
+        }
+
+        // Draw the score
+        text!("Score: {}", self.score; x = 10, y = 10, font = "large", color = 0xffffffff); // Render the score
+
+        // Uncomment to print game state for debugging
+        // text!(&format!("{:#?}", state), y = 24);
+
+        // Save game state for the next frame
+        self.frame += 1;
     }
-
-    // Draw the cat
-    sprite!(
-        "munch_cat",
-        x = state.cat_x - state.cat_r,
-        y = state.cat_y - 16.0
-    );
-
-    // Draw the falling pancakes
-    for pancake in &state.pancakes {
-        circ!(
-            x = pancake.x,
-            y = pancake.y + 1.0,
-            d = pancake.radius + 2.,
-            color = 0x000000aa
-        ); // Render the pancakes
-        circ!(
-            x = pancake.x,
-            y = pancake.y,
-            d = pancake.radius + 1.,
-            color = 0xf4d29cff
-        ); // Render the pancakes
-        circ!(
-            x = pancake.x,
-            y = pancake.y,
-            d = pancake.radius,
-            color = 0xdba463ff
-        ); // Render the pancakes
-    }
-
-    // Draw the score
-    text!("Score: {}", state.score; x = 10, y = 10, font = "large", color = 0xffffffff); // Render the score
-
-    // Uncomment to print game state for debugging
-    // text!(&format!("{:#?}", state), y = 24);
-
-    // Save game state for the next frame
-    state.frame += 1;
-    state.save();
-});
+}

--- a/platformer/Cargo.toml
+++ b/platformer/Cargo.toml
@@ -4,7 +4,9 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-turbo = { version = "^3.0.0", package = "turbo-genesis-sdk" }
+borsh = "1.5.7"
+camera = "0.1.0"
+turbo = { version = "^3.1.0", package = "turbo-genesis-sdk" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/platformer/src/lib.rs
+++ b/platformer/src/lib.rs
@@ -1,4 +1,4 @@
-use turbo::{borsh::BorshDeserialize, canvas::clear};
+use turbo::prelude::*;
 
 const TILE_SIZE: i32 = 16;
 const GRAVITY: f32 = 0.6;
@@ -11,6 +11,7 @@ const PLAYER_MAX_JUMP_FORCE: f32 = 5.5;
 const PLAYER_JUMP_POWER_DUR: i32 = 6;
 const PLAYER_COYOTE_TIMER_DUR: i32 = 3;
 
+#[derive(BorshDeserialize, BorshSerialize)]
 #[turbo::game]
 struct GameState {
     player: Player,

--- a/platformer/src/lib.rs
+++ b/platformer/src/lib.rs
@@ -1,3 +1,5 @@
+use turbo::{borsh::BorshDeserialize, canvas::clear};
+
 const TILE_SIZE: i32 = 16;
 const GRAVITY: f32 = 0.6;
 
@@ -9,11 +11,13 @@ const PLAYER_MAX_JUMP_FORCE: f32 = 5.5;
 const PLAYER_JUMP_POWER_DUR: i32 = 6;
 const PLAYER_COYOTE_TIMER_DUR: i32 = 3;
 
-turbo::init! {
-    struct GameState {
-        player: Player,
-        tiles: Vec<Tile>,
-    } = {
+#[turbo::game]
+struct GameState {
+    player: Player,
+    tiles: Vec<Tile>,
+}
+impl GameState {
+    fn new() -> Self {
         let mut tiles = Vec::new();
 
         //Bottom layer of tiles
@@ -35,22 +39,19 @@ turbo::init! {
             tiles,
         }
     }
-}
+    fn update(&mut self) {
+        clear(0xadd8e6ff);
+        for t in &mut self.tiles {
+            t.draw();
+        }
 
-turbo::go!({
-    let mut state = GameState::load();
-    clear(0xadd8e6ff);
-    for t in &mut state.tiles {
-        t.draw();
+        self.player.handle_input();
+        self.player.check_collision_tilemap(&self.tiles);
+        self.player.update_position();
+        camera::focus_rect(self.player.x, self.player.y, 16, 16);
+        self.player.draw();
     }
-
-    state.player.handle_input();
-    state.player.check_collision_tilemap(&state.tiles);
-    state.player.update_position();
-    camera::focus_rect(state.player.x, state.player.y, 16, 16);
-    state.player.draw();
-    state.save();
-});
+}
 
 #[derive(BorshDeserialize, BorshSerialize, Debug, Clone, PartialEq)]
 struct Player {

--- a/pong/Cargo.toml
+++ b/pong/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-turbo = { version = "^3.0.0", package = "turbo-genesis-sdk" }
+turbo = { version = "^3.1.0", package = "turbo-genesis-sdk" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/pong/src/lib.rs
+++ b/pong/src/lib.rs
@@ -1,21 +1,32 @@
-turbo::init! {
-    struct GameState {
-        p1_score: u32,
-        p2_score: u32,
-        paddle1: struct Paddle {
-            x: f32,
-            y: f32,
-            height: f32,
-        },
-        paddle2: Paddle,
-        ball: struct Ball {
-            x: f32,
-            y: f32,
-            velocity_x: f32,
-            velocity_y: f32,
-            radius: f32,
-        },
-    } = {
+use turbo::prelude::*;
+
+#[derive(Debug, Clone, PartialEq, BorshDeserialize, BorshSerialize)]
+struct Paddle {
+    x: f32,
+    y: f32,
+    height: f32,
+}
+
+#[derive(Debug, Clone, PartialEq, BorshDeserialize, BorshSerialize)]
+struct Ball {
+    x: f32,
+    y: f32,
+    velocity_x: f32,
+    velocity_y: f32,
+    radius: f32,
+}
+
+#[turbo::game]
+#[derive(Debug, Clone, PartialEq, BorshDeserialize, BorshSerialize)]
+struct GameState {
+    p1_score: u32,
+    p2_score: u32,
+    paddle1: Paddle,
+    paddle2: Paddle,
+    ball: Ball,
+}
+impl GameState {
+    fn new() -> Self {
         let canvas_size = resolution();
         let w = canvas_size.0 as f32;
         let h = canvas_size.1 as f32;
@@ -30,104 +41,98 @@ turbo::init! {
             ball: Ball { x: w / 2.0, y: h / 2.0, velocity_x: 2.0, velocity_y: 2.0, radius: ball_radius },
         }
     }
+    fn update(&mut self) {
+        let paddle_speed = 4.0;
+
+        let canvas_size = resolution();
+        let screen_w = canvas_size.0 as f32;
+        let screen_h = canvas_size.1 as f32;
+    
+        let gp1 = gamepad(0);
+        let gp2 = gamepad(1);
+    
+        // Debug log state
+        if gp1.start.pressed() || gp2.start.pressed() {
+            log!("{self:?}");
+        }
+    
+        // Move paddle 1
+        if gp1.up.pressed() && self.paddle1.y > 0.0 {
+            self.paddle1.y -= paddle_speed;
+        }
+        if gp1.down.pressed() && self.paddle1.y + self.paddle1.height < screen_h {
+            self.paddle1.y += paddle_speed;
+        }
+    
+        // Move paddle 2
+        if gp2.up.pressed() && self.paddle2.y > 0.0 {
+            self.paddle2.y -= paddle_speed;
+        }
+        if gp2.down.pressed() && self.paddle2.y + self.paddle2.height < screen_h {
+            self.paddle2.y += paddle_speed;
+        }
+    
+        // Update ball position
+        self.ball.x += self.ball.velocity_x;
+        self.ball.y += self.ball.velocity_y;
+    
+        // Ball out of bounds (scoring)
+        let did_p1_score = self.ball.x + self.ball.radius * 2.0 >= screen_w as f32;
+        if did_p1_score {
+            self.p1_score += 1;
+        }
+        let did_p2_score = self.ball.x < 0.0;
+        if did_p2_score {
+            self.p2_score += 1;
+        }
+        if did_p1_score || did_p2_score {
+            // Reset ball position
+            self.ball.x = screen_w as f32 / 2.0;
+            self.ball.y = screen_h / 2.0;
+        }
+    
+        // Ball collisions with paddles
+        if (self.ball.x - self.ball.radius < self.paddle1.x + 8.0
+            && self.ball.y > self.paddle1.y
+            && self.ball.y < self.paddle1.y + self.paddle1.height)
+            || (self.ball.x + self.ball.radius > self.paddle2.x
+                && self.ball.y > self.paddle2.y
+                && self.ball.y < self.paddle2.y + self.paddle2.height)
+        {
+            self.ball.velocity_x = -self.ball.velocity_x;
+        }
+    
+        // Ball collisions with top and bottom
+        if self.ball.y - self.ball.radius < 0.0 || self.ball.y + self.ball.radius > screen_h {
+            self.ball.velocity_y = -self.ball.velocity_y;
+        }
+    
+        // Draw paddles and ball
+        rect!(
+            x = self.paddle1.x as i32,
+            y = self.paddle1.y as i32,
+            w = 8,
+            h = self.paddle1.height as u32,
+            color = 0xffffffff
+        );
+        rect!(
+            x = self.paddle2.x as i32,
+            y = self.paddle2.y as i32,
+            w = 8,
+            h = self.paddle2.height as u32,
+            color = 0xffffffff
+        );
+        circ!(
+            x = self.ball.x as i32,
+            y = self.ball.y as i32,
+            d = self.ball.radius as u32,
+            color = 0xffffffff
+        );
+        text!("P1: {}", self.p1_score; font = "large", x = 64);
+        text!(
+            "P2: {}", self.p2_score;
+            font = "large",
+            x = (screen_w as i32 / 2) + 64
+        );
+    }
 }
-
-turbo::go!({
-    let mut state = GameState::load();
-
-    let paddle_speed = 4.0;
-
-    let canvas_size = resolution();
-    let screen_w = canvas_size.0 as f32;
-    let screen_h = canvas_size.1 as f32;
-
-    let gp1 = gamepad(0);
-    let gp2 = gamepad(1);
-
-    // Debug log state
-    if gp1.start.pressed() || gp2.start.pressed() {
-        log!("{state:?}");
-    }
-
-    // Move paddle 1
-    if gp1.up.pressed() && state.paddle1.y > 0.0 {
-        state.paddle1.y -= paddle_speed;
-    }
-    if gp1.down.pressed() && state.paddle1.y + state.paddle1.height < screen_h {
-        state.paddle1.y += paddle_speed;
-    }
-
-    // Move paddle 2
-    if gp2.up.pressed() && state.paddle2.y > 0.0 {
-        state.paddle2.y -= paddle_speed;
-    }
-    if gp2.down.pressed() && state.paddle2.y + state.paddle2.height < screen_h {
-        state.paddle2.y += paddle_speed;
-    }
-
-    // Update ball position
-    state.ball.x += state.ball.velocity_x;
-    state.ball.y += state.ball.velocity_y;
-
-    // Ball out of bounds (scoring)
-    let did_p1_score = state.ball.x + state.ball.radius * 2.0 >= screen_w as f32;
-    if did_p1_score {
-        state.p1_score += 1;
-    }
-    let did_p2_score = state.ball.x < 0.0;
-    if did_p2_score {
-        state.p2_score += 1;
-    }
-    if did_p1_score || did_p2_score {
-        // Reset ball position
-        state.ball.x = screen_w as f32 / 2.0;
-        state.ball.y = screen_h / 2.0;
-    }
-
-    // Ball collisions with paddles
-    if (state.ball.x - state.ball.radius < state.paddle1.x + 8.0
-        && state.ball.y > state.paddle1.y
-        && state.ball.y < state.paddle1.y + state.paddle1.height)
-        || (state.ball.x + state.ball.radius > state.paddle2.x
-            && state.ball.y > state.paddle2.y
-            && state.ball.y < state.paddle2.y + state.paddle2.height)
-    {
-        state.ball.velocity_x = -state.ball.velocity_x;
-    }
-
-    // Ball collisions with top and bottom
-    if state.ball.y - state.ball.radius < 0.0 || state.ball.y + state.ball.radius > screen_h {
-        state.ball.velocity_y = -state.ball.velocity_y;
-    }
-
-    // Draw paddles and ball
-    rect!(
-        x = state.paddle1.x as i32,
-        y = state.paddle1.y as i32,
-        w = 8,
-        h = state.paddle1.height as u32,
-        color = 0xffffffff
-    );
-    rect!(
-        x = state.paddle2.x as i32,
-        y = state.paddle2.y as i32,
-        w = 8,
-        h = state.paddle2.height as u32,
-        color = 0xffffffff
-    );
-    circ!(
-        x = state.ball.x as i32,
-        y = state.ball.y as i32,
-        d = state.ball.radius as u32,
-        color = 0xffffffff
-    );
-    text!("P1: {}", state.p1_score; font = "large", x = 64);
-    text!(
-        "P2: {}", state.p2_score;
-        font = "large",
-        x = (screen_w as i32 / 2) + 64
-    );
-
-    // Save game state for the next frame
-    state.save();
-});

--- a/rectrunner/Cargo.toml
+++ b/rectrunner/Cargo.toml
@@ -4,6 +4,7 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
+borsh = "1.5.7"
 turbo = { version = "^3.0.0", package = "turbo-genesis-sdk" }
 
 [lib]

--- a/rectrunner/src/lib.rs
+++ b/rectrunner/src/lib.rs
@@ -1,5 +1,7 @@
 use turbo::{
-    borsh::BorshDeserialize, canvas::{circ, clear, rect, sprite, text}, input::gamepad, sys::rand
+    canvas::{circ, clear, rect, sprite, text},
+    input::gamepad,
+    sys::rand,
 };
 
 #[turbo::game]
@@ -70,7 +72,7 @@ impl GameState {
             // Check for restart input
             if input.start.pressed() {
                 // Reset the game state
-                self = &mut GameState {
+                *self = GameState {
                     frame: 0,
                     player_x: 30.0,
                     player_y: 10.0,
@@ -317,7 +319,7 @@ impl GameState {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, BorshDeserialize, BorshSerialize)]
+#[derive(Debug, Clone, PartialEq)]
 struct Obstacle {
     x: f32,
     y: f32,
@@ -325,7 +327,7 @@ struct Obstacle {
     height: f32,
 }
 
-#[derive(Debug, Clone, PartialEq, BorshDeserialize, BorshSerialize)]
+#[derive(Debug, Clone, PartialEq)]
 struct Coin {
     x: f32,
     y: f32,

--- a/rectrunner/src/lib.rs
+++ b/rectrunner/src/lib.rs
@@ -1,9 +1,6 @@
-use turbo::{
-    canvas::{circ, clear, rect, sprite, text},
-    input::gamepad,
-    sys::rand,
-};
+use turbo::prelude::*;
 
+#[derive(BorshDeserialize, BorshSerialize)]
 #[turbo::game]
 struct GameState {
     frame: u32,
@@ -319,7 +316,7 @@ impl GameState {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, BorshDeserialize, BorshSerialize)]
 struct Obstacle {
     x: f32,
     y: f32,
@@ -327,7 +324,7 @@ struct Obstacle {
     height: f32,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, BorshDeserialize, BorshSerialize)]
 struct Coin {
     x: f32,
     y: f32,

--- a/rectrunner/src/lib.rs
+++ b/rectrunner/src/lib.rs
@@ -1,25 +1,29 @@
-// Define the game configuration
+use turbo::{
+    borsh::BorshDeserialize, canvas::{circ, clear, rect, sprite, text}, input::gamepad, sys::rand
+};
 
-// Define the game state
-turbo::init! {
-    struct GameState {
-        frame: u32,
-        player_x: f32,
-        player_y: f32,
-        velocity_y: f32,
-        obstacles: Vec<Obstacle>,
-        coins: Vec<Coin>,
-        score: u32,
-        lives: u32,
-        is_game_over: bool,
-        is_started: bool,
-        speed: f32,
-        collision_cooldown: u32,
-        acceleration: f32,
-        max_speed: f32,
-        bg_x: f32,
-        fg_x: f32,
-    } = {
+#[turbo::game]
+struct GameState {
+    frame: u32,
+    player_x: f32,
+    player_y: f32,
+    velocity_y: f32,
+    obstacles: Vec<Obstacle>,
+    coins: Vec<Coin>,
+    score: u32,
+    lives: u32,
+    is_game_over: bool,
+    is_started: bool,
+    speed: f32,
+    collision_cooldown: u32,
+    acceleration: f32,
+    max_speed: f32,
+    bg_x: f32,
+    fg_x: f32,
+}
+
+impl GameState {
+    fn new() -> Self {
         Self {
             frame: 0,
             player_x: 30.0,
@@ -39,6 +43,278 @@ turbo::init! {
             fg_x: 0.0,
         }
     }
+    fn update(&mut self) {
+        let input = gamepad(0);
+
+        if !self.is_started {
+            // Check for start input
+            if input.start.pressed() {
+                self.is_started = true;
+            }
+
+            // Clear the screen
+            clear(0x00ffffff);
+
+            // Draw the background rectangle for the "Press Start to Play" text
+            rect!(x = -75, y = 0, w = 350, h = 200, color = 0x000000ff); // Combined height and position
+
+            // Display Start message
+            text!(
+                "Press Start to Play",
+                x = 55,
+                y = 70,
+                font = "large",
+                color = 0xffd700ff
+            );
+        } else if self.is_game_over {
+            // Check for restart input
+            if input.start.pressed() {
+                // Reset the game state
+                self = &mut GameState {
+                    frame: 0,
+                    player_x: 30.0,
+                    player_y: 10.0,
+                    velocity_y: 0.0,
+                    obstacles: vec![],
+                    coins: vec![],
+                    score: 0,
+                    lives: 1, // Reset lives to three
+                    is_game_over: false,
+                    is_started: true,
+                    speed: 2.0,
+                    collision_cooldown: 0,
+                    acceleration: 0.001, // Reset acceleration
+                    max_speed: 5.0,      // Reset maximum speed
+                    bg_x: 0.0,           // Reset background position
+                    fg_x: 0.0,           // Reset foreground position
+                };
+            }
+
+            // Clear the screen
+            clear(0x00ffffff);
+
+            // Draw the background rectangle for both "Game Over" and "Press Start to Restart" texts
+            rect!(x = -75, y = 0, w = 350, h = 200, color = 0x000000ff); // Combined height and position
+
+            // Display Game Over message
+            text!(
+                "Game Over",
+                x = 98,
+                y = 70,
+                font = "large",
+                color = 0xff0000ff
+            );
+
+            // Display Restart message
+            text!(
+                "Press Start to Restart",
+                x = 80,
+                y = 90,
+                font = "medium",
+                color = 0x00ffffff
+            );
+        } else {
+            // Handle user input for jumping
+            if input.up.pressed() {
+                self.velocity_y = -3.0; // Move up
+            }
+
+            // Apply gravity and update player position
+            self.velocity_y += 0.2; // Gravity
+            self.player_y += self.velocity_y;
+
+            // Ensure the player stays within the screen bounds
+            if self.player_y < 0.0 {
+                self.player_y = 0.0;
+                self.velocity_y = 0.0;
+            } else if self.player_y > 144.0 - 10.0 {
+                self.player_y = 144.0 - 10.0;
+                self.velocity_y = 0.0;
+            }
+
+            // Update obstacles and coins
+            for obstacle in &mut self.obstacles {
+                obstacle.x -= self.speed;
+            }
+            for coin in &mut self.coins {
+                coin.x -= self.speed;
+            }
+
+            // Remove off-screen obstacles and coins
+            self.obstacles.retain(|o| o.x + o.width > 0.0);
+            self.coins.retain(|c| c.x > -5.0);
+            // Generate new obstacles with dynamic gap size and more randomness
+            if self.frame % 60 == 0 {
+                let height = (rand() % 50 + 20) as f32; // Random height between 20 and 70
+
+                // Add more variability to the gap size
+                let base_gap = 50.0;
+                let gap_variability = (rand() % 40 - 20) as f32; // Random variability between -20 and 20
+                let gap = base_gap + (self.score / 100) as f32 + gap_variability;
+
+                // Add the top obstacle
+                self.obstacles.push(Obstacle {
+                    x: 256.0,
+                    y: 144.0 - height,
+                    width: 10.0,
+                    height,
+                });
+
+                // Add the bottom obstacle
+                self.obstacles.push(Obstacle {
+                    x: 256.0,
+                    y: 0.0,
+                    width: 10.0,
+                    height: 144.0 - height - gap,
+                });
+
+                // Randomly generate an additional obstacle for more unpredictability
+                if rand() % 10 < 3 {
+                    // 30% chance to add an additional obstacle
+                    let extra_height = (rand() % 50 + 10) as f32; // Random height between 10 and 60
+                    let extra_gap = base_gap + (rand() % 30 - 15) as f32; // Random variability between -15 and 15
+                    self.obstacles.push(Obstacle {
+                        x: 256.0 + (rand() % 30 + 20) as f32, // Random x position between 20 and 50
+                        y: 144.0 - extra_height,
+                        width: 10.0,
+                        height: extra_height,
+                    });
+                    self.obstacles.push(Obstacle {
+                        x: 256.0 + (rand() % 30 + 20) as f32,
+                        y: 0.0,
+                        width: 10.0,
+                        height: 144.0 - extra_height - extra_gap,
+                    });
+                }
+            }
+
+            // Generate new coins less frequently
+            if self.frame % 300 == 0 {
+                // Adjust the frequency here
+                self.coins.push(Coin {
+                    x: 256.0,
+                    y: (rand() % 120) as f32,
+                });
+            }
+
+            // Update background and foreground positions
+            self.bg_x -= self.speed * 0.5;
+            self.fg_x -= self.speed;
+
+            // Reset positions for continuous scrolling
+            if self.bg_x <= -256.0 {
+                self.bg_x = 0.0;
+            }
+            if self.fg_x <= -256.0 {
+                self.fg_x = 0.0;
+            }
+
+            // Check for collisions with obstacles
+            let player_width = 10.0;
+            let player_height = 10.0;
+            let mut has_collision = false;
+
+            for obstacle in &self.obstacles {
+                if self.player_x < obstacle.x + obstacle.width
+                    && self.player_x + player_width > obstacle.x
+                    && self.player_y < obstacle.y + obstacle.height
+                    && self.player_y + player_height > obstacle.y
+                {
+                    has_collision = true;
+                    break;
+                }
+            }
+
+            if has_collision && self.collision_cooldown == 0 {
+                if self.lives > 0 {
+                    self.lives -= 1;
+                    self.player_x = 30.0;
+                    self.player_y = 10.0;
+                    self.velocity_y = 0.0;
+                    self.collision_cooldown = 30; // Set cooldown to prevent multiple decrements
+                } else {
+                    self.is_game_over = true;
+                }
+            }
+
+            // Handle collision cooldown
+            if self.collision_cooldown > 0 {
+                self.collision_cooldown -= 1;
+            }
+
+            // Check for coin collection
+            let mut coins_to_remove = Vec::new();
+            for (i, coin) in self.coins.iter().enumerate() {
+                if self.player_x < coin.x + 5.0
+                    && self.player_x + 10.0 > coin.x
+                    && self.player_y < coin.y + 5.0
+                    && self.player_y + 10.0 > coin.y
+                {
+                    coins_to_remove.push(i); // Collect the index for removal
+                    self.lives += 1; // Increase a life
+                }
+            }
+
+            // Remove collected coins by index
+            for &i in coins_to_remove.iter().rev() {
+                self.coins.remove(i);
+            }
+
+            // Increase score
+            self.score += 1;
+
+            // Gradually increase speed over time, but cap it at maximum speed
+            if self.speed < self.max_speed {
+                self.speed += self.acceleration;
+                if self.speed > self.max_speed {
+                    self.speed = self.max_speed;
+                }
+            }
+
+            // Clear the screen
+            clear(0x00ffffff);
+
+            // Draw the background
+            sprite!("bg_mountains", x = self.bg_x, y = 70);
+            sprite!("bg_mountains", x = self.bg_x + 256.0, y = 70,);
+
+            // Draw the foreground
+            sprite!("fg_path", x = self.fg_x as i32, y = 120,);
+            sprite!("fg_path", x = self.fg_x + 256.0, y = 120,);
+
+            // Draw the player
+            sprite!(
+                "npc_spex",
+                x = self.player_x - 5.0,
+                y = self.player_y - 25.0,
+            );
+
+            // Draw obstacles
+            for obstacle in &self.obstacles {
+                rect!(
+                    x = obstacle.x,
+                    y = obstacle.y,
+                    w = obstacle.width,
+                    h = obstacle.height,
+                    color = 0x555555ff
+                );
+            }
+
+            // Draw coins
+            for coin in &self.coins {
+                circ!(x = coin.x, y = coin.y, d = 5, color = 0xffd700ff);
+            }
+
+            // Draw the dark background rectangle for the score and lives area
+            rect!(x = 0, y = 0, w = 256, h = 20, color = 0x000000ff);
+
+            // Draw the score and lives text
+            text!("Score: {}", self.score; x = 10, y = 6, font = "medium", color = 0x00ffffff);
+            text!("Lives: {}", self.lives; x = 175, y = 6, font = "medium", color = 0x00ffffff);
+
+            self.frame += 1;
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, BorshDeserialize, BorshSerialize)]
@@ -54,281 +330,3 @@ struct Coin {
     x: f32,
     y: f32,
 }
-
-turbo::go!({
-    let mut state = GameState::load();
-
-    let input = gamepad(0);
-
-    if !state.is_started {
-        // Check for start input
-        if input.start.pressed() {
-            state.is_started = true;
-        }
-
-        // Clear the screen
-        clear(0x00ffffff);
-
-        // Draw the background rectangle for the "Press Start to Play" text
-        rect!(x = -75, y = 0, w = 350, h = 200, color = 0x000000ff); // Combined height and position
-
-        // Display Start message
-        text!(
-            "Press Start to Play",
-            x = 55,
-            y = 70,
-            font = "large",
-            color = 0xffd700ff
-        );
-    } else if state.is_game_over {
-        // Check for restart input
-        if input.start.pressed() {
-            // Reset the game state
-            state = GameState {
-                frame: 0,
-                player_x: 30.0,
-                player_y: 10.0,
-                velocity_y: 0.0,
-                obstacles: vec![],
-                coins: vec![],
-                score: 0,
-                lives: 1, // Reset lives to three
-                is_game_over: false,
-                is_started: true,
-                speed: 2.0,
-                collision_cooldown: 0,
-                acceleration: 0.001, // Reset acceleration
-                max_speed: 5.0,      // Reset maximum speed
-                bg_x: 0.0,           // Reset background position
-                fg_x: 0.0,           // Reset foreground position
-            };
-        }
-
-        // Clear the screen
-        clear(0x00ffffff);
-
-        // Draw the background rectangle for both "Game Over" and "Press Start to Restart" texts
-        rect!(x = -75, y = 0, w = 350, h = 200, color = 0x000000ff); // Combined height and position
-
-        // Display Game Over message
-        text!(
-            "Game Over",
-            x = 98,
-            y = 70,
-            font = "large",
-            color = 0xff0000ff
-        );
-
-        // Display Restart message
-        text!(
-            "Press Start to Restart",
-            x = 80,
-            y = 90,
-            font = "medium",
-            color = 0x00ffffff
-        );
-    } else {
-        // Handle user input for jumping
-        if input.up.pressed() {
-            state.velocity_y = -3.0; // Move up
-        }
-
-        // Apply gravity and update player position
-        state.velocity_y += 0.2; // Gravity
-        state.player_y += state.velocity_y;
-
-        // Ensure the player stays within the screen bounds
-        if state.player_y < 0.0 {
-            state.player_y = 0.0;
-            state.velocity_y = 0.0;
-        } else if state.player_y > 144.0 - 10.0 {
-            state.player_y = 144.0 - 10.0;
-            state.velocity_y = 0.0;
-        }
-
-        // Update obstacles and coins
-        for obstacle in &mut state.obstacles {
-            obstacle.x -= state.speed;
-        }
-        for coin in &mut state.coins {
-            coin.x -= state.speed;
-        }
-
-        // Remove off-screen obstacles and coins
-        state.obstacles.retain(|o| o.x + o.width > 0.0);
-        state.coins.retain(|c| c.x > -5.0);
-        // Generate new obstacles with dynamic gap size and more randomness
-        if state.frame % 60 == 0 {
-            let height = (rand() % 50 + 20) as f32; // Random height between 20 and 70
-
-            // Add more variability to the gap size
-            let base_gap = 50.0;
-            let gap_variability = (rand() % 40 - 20) as f32; // Random variability between -20 and 20
-            let gap = base_gap + (state.score / 100) as f32 + gap_variability;
-
-            // Add the top obstacle
-            state.obstacles.push(Obstacle {
-                x: 256.0,
-                y: 144.0 - height,
-                width: 10.0,
-                height,
-            });
-
-            // Add the bottom obstacle
-            state.obstacles.push(Obstacle {
-                x: 256.0,
-                y: 0.0,
-                width: 10.0,
-                height: 144.0 - height - gap,
-            });
-
-            // Randomly generate an additional obstacle for more unpredictability
-            if rand() % 10 < 3 {
-                // 30% chance to add an additional obstacle
-                let extra_height = (rand() % 50 + 10) as f32; // Random height between 10 and 60
-                let extra_gap = base_gap + (rand() % 30 - 15) as f32; // Random variability between -15 and 15
-                state.obstacles.push(Obstacle {
-                    x: 256.0 + (rand() % 30 + 20) as f32, // Random x position between 20 and 50
-                    y: 144.0 - extra_height,
-                    width: 10.0,
-                    height: extra_height,
-                });
-                state.obstacles.push(Obstacle {
-                    x: 256.0 + (rand() % 30 + 20) as f32,
-                    y: 0.0,
-                    width: 10.0,
-                    height: 144.0 - extra_height - extra_gap,
-                });
-            }
-        }
-
-        // Generate new coins less frequently
-        if state.frame % 300 == 0 {
-            // Adjust the frequency here
-            state.coins.push(Coin {
-                x: 256.0,
-                y: (rand() % 120) as f32,
-            });
-        }
-
-        // Update background and foreground positions
-        state.bg_x -= state.speed * 0.5;
-        state.fg_x -= state.speed;
-
-        // Reset positions for continuous scrolling
-        if state.bg_x <= -256.0 {
-            state.bg_x = 0.0;
-        }
-        if state.fg_x <= -256.0 {
-            state.fg_x = 0.0;
-        }
-
-        // Check for collisions with obstacles
-        let player_width = 10.0;
-        let player_height = 10.0;
-        let mut has_collision = false;
-
-        for obstacle in &state.obstacles {
-            if state.player_x < obstacle.x + obstacle.width
-                && state.player_x + player_width > obstacle.x
-                && state.player_y < obstacle.y + obstacle.height
-                && state.player_y + player_height > obstacle.y
-            {
-                has_collision = true;
-                break;
-            }
-        }
-
-        if has_collision && state.collision_cooldown == 0 {
-            if state.lives > 0 {
-                state.lives -= 1;
-                state.player_x = 30.0;
-                state.player_y = 10.0;
-                state.velocity_y = 0.0;
-                state.collision_cooldown = 30; // Set cooldown to prevent multiple decrements
-            } else {
-                state.is_game_over = true;
-            }
-        }
-
-        // Handle collision cooldown
-        if state.collision_cooldown > 0 {
-            state.collision_cooldown -= 1;
-        }
-
-        // Check for coin collection
-        let mut coins_to_remove = Vec::new();
-        for (i, coin) in state.coins.iter().enumerate() {
-            if state.player_x < coin.x + 5.0
-                && state.player_x + 10.0 > coin.x
-                && state.player_y < coin.y + 5.0
-                && state.player_y + 10.0 > coin.y
-            {
-                coins_to_remove.push(i); // Collect the index for removal
-                state.lives += 1; // Increase a life
-            }
-        }
-
-        // Remove collected coins by index
-        for &i in coins_to_remove.iter().rev() {
-            state.coins.remove(i);
-        }
-
-        // Increase score
-        state.score += 1;
-
-        // Gradually increase speed over time, but cap it at maximum speed
-        if state.speed < state.max_speed {
-            state.speed += state.acceleration;
-            if state.speed > state.max_speed {
-                state.speed = state.max_speed;
-            }
-        }
-
-        // Clear the screen
-        clear(0x00ffffff);
-
-        // Draw the background
-        sprite!("bg_mountains", x = state.bg_x, y = 70);
-        sprite!("bg_mountains", x = state.bg_x + 256.0, y = 70,);
-
-        // Draw the foreground
-        sprite!("fg_path", x = state.fg_x as i32, y = 120,);
-        sprite!("fg_path", x = state.fg_x + 256.0, y = 120,);
-
-        // Draw the player
-        sprite!(
-            "npc_spex",
-            x = state.player_x - 5.0,
-            y = state.player_y - 25.0,
-        );
-
-        // Draw obstacles
-        for obstacle in &state.obstacles {
-            rect!(
-                x = obstacle.x,
-                y = obstacle.y,
-                w = obstacle.width,
-                h = obstacle.height,
-                color = 0x555555ff
-            );
-        }
-
-        // Draw coins
-        for coin in &state.coins {
-            circ!(x = coin.x, y = coin.y, d = 5, color = 0xffd700ff);
-        }
-
-        // Draw the dark background rectangle for the score and lives area
-        rect!(x = 0, y = 0, w = 256, h = 20, color = 0x000000ff);
-
-        // Draw the score and lives text
-        text!("Score: {}", state.score; x = 10, y = 6, font = "medium", color = 0x00ffffff);
-        text!("Lives: {}", state.lives; x = 175, y = 6, font = "medium", color = 0x00ffffff);
-
-        state.frame += 1;
-    }
-
-    // Save the updated state
-    state.save();
-});

--- a/space-invaders/Cargo.toml
+++ b/space-invaders/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-turbo = { version = "^3.0.0", package = "turbo-genesis-sdk" }
+turbo = { version = "^3.1.0", package = "turbo-genesis-sdk" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/space-invaders/src/lib.rs
+++ b/space-invaders/src/lib.rs
@@ -1,8 +1,6 @@
-use turbo::{
-    canvas::{rect, sprite, text},
-    input::gamepad,
-};
+use turbo::prelude::*;
 
+#[derive(BorshDeserialize, BorshSerialize)]
 struct Invader {
     x: f32,
     y: f32,
@@ -10,11 +8,13 @@ struct Invader {
     sprites: [String; 2],
 }
 
+#[derive(BorshDeserialize, BorshSerialize)]
 struct Bullet {
     x: f32,
     y: f32,
 }
 
+#[derive(BorshDeserialize, BorshSerialize)]
 #[turbo::game]
 struct GameState {
     player_x: f32,

--- a/space-shooter/Cargo.toml
+++ b/space-shooter/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-turbo = { version = "^3.0.0", package = "turbo-genesis-sdk" }
+turbo = { version = "^3.1.0", package = "turbo-genesis-sdk" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/space-shooter/src/lib.rs
+++ b/space-shooter/src/lib.rs
@@ -1,5 +1,6 @@
 use turbo::prelude::*;
-use turbo::{borsh::BorshDeserialize, input::gamepad, log, sys::rand};
+
+#[derive(BorshDeserialize, BorshSerialize)]
 #[turbo::game]
 struct GameState {
     tick: u32,
@@ -81,7 +82,7 @@ impl GameState {
             // Restart
             if self.hit_timer == 0 && gamepad(0).start.just_pressed() || gamepad(0).a.just_pressed()
             {
-                GameState::new(); // running into an error here I cant solve
+                *self = Self::new()
             }
         } else {
             // Player movement handling

--- a/space-shooter/src/lib.rs
+++ b/space-shooter/src/lib.rs
@@ -1,27 +1,25 @@
-turbo::init! {
-    struct GameState {
-        tick: u32,
-        notification_timer: u32,
-        hit_timer: u32,
+use turbo::prelude::*;
+use turbo::{borsh::BorshDeserialize, input::gamepad, log, sys::rand};
+#[turbo::game]
+struct GameState {
+    tick: u32,
+    notification_timer: u32,
+    hit_timer: u32,
 
-        // Game elements
-        score: u32,
-        tutorial_active: bool,
-        help_messages: Vec<String>,
-        notifications: Vec<String>,
+    // Game elements
+    score: u32,
+    tutorial_active: bool,
+    help_messages: Vec<String>,
+    notifications: Vec<String>,
 
-        // Entities
-        player: Player,
-        projectiles: Vec<Projectile>,
-        enemies: Vec<Enemy>,
-        powerups: Vec<Powerup>,
-    } = {
-        Self::new()
-    }
+    // Entities
+    player: Player,
+    projectiles: Vec<Projectile>,
+    enemies: Vec<Enemy>,
+    powerups: Vec<Powerup>,
 }
-
 impl GameState {
-    pub fn new() -> Self {
+    fn new() -> Self {
         let (screen_w, screen_h) = resolution();
         Self {
             // Initialize all fields with default values
@@ -65,483 +63,519 @@ impl GameState {
             powerups: vec![],
         }
     }
-}
-
-turbo::go!({
-    let mut state = GameState::load();
-    if gamepad(0).b.pressed() {
-        let health = state.player.health;
-        let xy = (state.player.x, state.player.y);
-        let score = state.score;
-        let canvas_size = resolution();
-        log!("- Health = {health}\n- Position: {xy:?}\n- Score: {score}\n- Resolution: {canvas_size:?}");
-    }
-
-    let (screen_w, screen_h) = resolution();
-
-    // Drawing all game elements, including player, enemies, environment, and UI
-    draw_game_elements(&state);
-
-    if state.player.health == 0 {
-        // Restart
-        if state.hit_timer == 0 && gamepad(0).start.just_pressed() || gamepad(0).a.just_pressed() {
-            state = GameState::new();
-        }
-    } else {
-        // Player movement handling
-        if gamepad(0).up.pressed() {
-            state.player.y = (state.player.y - state.player.speed).max(0.0); // Move up
-        }
-        if gamepad(0).down.pressed() {
-            state.player.y = (state.player.y + state.player.speed).min((screen_h - state.player.height) as f32); // Move down
-        }
-        if gamepad(0).left.pressed() {
-            state.player.x = (state.player.x - state.player.speed).max(0.0); // Move left
-        }
-        if gamepad(0).right.pressed() {
-            state.player.x = (state.player.x + state.player.speed).min((screen_w - state.player.width) as f32); // Move right
+    fn update(&mut self) {
+        if gamepad(0).b.pressed() {
+            let health = self.player.health;
+            let xy = (self.player.x, self.player.y);
+            let score = self.score;
+            let canvas_size = resolution();
+            log!("- Health = {health}\n- Position: {xy:?}\n- Score: {score}\n- Resolution: {canvas_size:?}");
         }
 
-        // Shooting projectiles
-        if gamepad(0).start.just_pressed() || gamepad(0).a.just_pressed() {
-            state.projectiles.push(Projectile {
-                x: state.player.x + ((state.player.width / 2) as f32) - 2.0,
-                y: state.player.y,
+        let (screen_w, screen_h) = resolution();
+
+        // Drawing all game elements, including player, enemies, environment, and UI
+        Self::draw_game_elements(&self);
+
+        if self.player.health == 0 {
+            // Restart
+            if self.hit_timer == 0 && gamepad(0).start.just_pressed() || gamepad(0).a.just_pressed()
+            {
+                self = &mut GameState::new(); // running into an error here I cant solve
+            }
+        } else {
+            // Player movement handling
+            if gamepad(0).up.pressed() {
+                self.player.y = (self.player.y - self.player.speed).max(0.0);
+                // Move up
+            }
+            if gamepad(0).down.pressed() {
+                self.player.y =
+                    (self.player.y + self.player.speed).min((screen_h - self.player.height) as f32);
+                // Move down
+            }
+            if gamepad(0).left.pressed() {
+                self.player.x = (self.player.x - self.player.speed).max(0.0);
+                // Move left
+            }
+            if gamepad(0).right.pressed() {
+                self.player.x =
+                    (self.player.x + self.player.speed).min((screen_w - self.player.width) as f32);
+                // Move right
+            }
+
+            // Shooting projectiles
+            if gamepad(0).start.just_pressed() || gamepad(0).a.just_pressed() {
+                self.projectiles.push(Projectile {
+                    x: self.player.x + ((self.player.width / 2) as f32) - 2.0,
+                    y: self.player.y,
+                    width: 8,
+                    height: 8,
+                    velocity: 5.0,
+                    angle: -90.0,
+                    damage: self.player.projectile_damage,
+                    projectile_type: self.player.projectile_type,
+                    projectile_owner: ProjectileOwner::Player,
+                    ttl: None,
+                });
+            }
+        }
+
+        // Every 30s, spawn a heal at a random location
+        if self.tick % (60 * 30) == 0 {
+            self.powerups.push(Powerup {
+                x: (rand() % screen_w) as f32,
+                y: 24.0 + (rand() % screen_h / 2) as f32,
                 width: 8,
                 height: 8,
-                velocity: 5.0,
-                angle: -90.0,
-                damage: state.player.projectile_damage,
-                projectile_type: state.player.projectile_type,
-                projectile_owner: ProjectileOwner::Player,
-                ttl: None,
+                effect: PowerupEffect::Heal,
+                movement: PowerupMovement::Drifting(0.75),
             });
         }
-    }
 
-    // Every 30s, spawn a heal at a random location
-    if state.tick % (60 * 30) == 0 {
-        state.powerups.push(Powerup {
-            x: (rand() % screen_w) as f32,
-            y: 24.0 + (rand() % screen_h / 2) as f32,
-            width: 8,
-            height: 8,
-            effect: PowerupEffect::Heal,
-            movement: PowerupMovement::Drifting(0.75),
-        });
-    }
-
-    // Spawn a heal every 10s when player's health is low
-    if state.tick % (60 * 10) == 0 && state.player.health == 1 {
-        state.powerups.push(Powerup {
-            x: (rand() % screen_w) as f32,
-            y: (rand() % screen_h) as f32,
-            width: 8,
-            height: 8,
-            effect: PowerupEffect::MaxHealthUp,
-            movement: PowerupMovement::Floating(0.5),
-        });
-    }
-
-
-    // Start spawning enemies after intro dialog
-    if state.tick > (state.notifications.len() as u32 + 1) * 240 {
-        // Enemy spawning logic based on time elapsed
-        // Define spawn intervals (in ticks) for enemies
-        let initial_spawn_rate: u32 = 100; // Initial interval for enemy spawn
-        let minimum_spawn_rate = 25; // Minimum interval after speeding up
-        let speed_up_rate = 60 * 2; // Interval after which spawn rate increases
-
-        // Calculate current spawn interval based on time elapsed
-        let spawn_rate = std::cmp::max(
-            minimum_spawn_rate,
-            initial_spawn_rate.saturating_sub(state.tick / speed_up_rate)
-        );
-        if state.player.health > 0 {
-            text!("spawn rate: {}", spawn_rate; x = 4, y = 22, font = "small");
-        }
-        if state.tick % spawn_rate == 0 && state.enemies.len() < 24 {
-            state.enemies.push(match rand() % 8 {
-                0 => Enemy::tank(),
-                1 => Enemy::tank(),
-                2 => Enemy::shooter(),
-                3 => Enemy::shooter(),
-                4 => Enemy::meteor(),
-                5 => Enemy::zipper(),
-                6 => Enemy::turret(),
-                7 => Enemy::turret(),
-                _ => unreachable!()
+        // Spawn a heal every 10s when player's health is low
+        if self.tick % (60 * 10) == 0 && self.player.health == 1 {
+            self.powerups.push(Powerup {
+                x: (rand() % screen_w) as f32,
+                y: (rand() % screen_h) as f32,
+                width: 8,
+                height: 8,
+                effect: PowerupEffect::MaxHealthUp,
+                movement: PowerupMovement::Floating(0.5),
             });
         }
-    }
-    // Handle player picking up power-ups
-    state.powerups.retain(|powerup| {
-        if check_collision(powerup.x, powerup.y, powerup.width, powerup.height,
-                        state.player.x, state.player.y, state.player.width, state.player.height) {
-            match powerup.effect {
-                PowerupEffect::Heal => {
-                    state.player.health = (state.player.health + 1).min(state.player.max_health);
-                    state.player.skill_points += 1;
-                    state.notifications.push("+1 Health".to_string());
-                },
-                PowerupEffect::MaxHealthUp => {
-                    state.player.max_health = (state.player.max_health + 1).min(10);
-                    state.player.health = state.player.max_health;
-                    state.player.skill_points += 1;
-                    state.notifications.push("Max Health +1".to_string());
-                },
-                PowerupEffect::SpeedBoost => {
-                    state.player.speed *= 1.1;
-                    state.player.skill_points += 1;
-                    state.notifications.push("1.1x Speed Boost".to_string());
-                },
-                PowerupEffect::DamageBoost(projectile_type) => {
-                    if state.player.projectile_type == projectile_type {
-                        state.notifications.push(format!("+1 {projectile_type:?} Damage"));
-                        state.player.skill_points += 1;
-                        state.player.projectile_damage = (state.player.projectile_damage + 1).min(2);
+
+        // Start spawning enemies after intro dialog
+        if self.tick > (self.notifications.len() as u32 + 1) * 240 {
+            // Enemy spawning logic based on time elapsed
+            // Define spawn intervals (in ticks) for enemies
+            let initial_spawn_rate: u32 = 100; // Initial interval for enemy spawn
+            let minimum_spawn_rate = 25; // Minimum interval after speeding up
+            let speed_up_rate = 60 * 2; // Interval after which spawn rate increases
+
+            // Calculate current spawn interval based on time elapsed
+            let spawn_rate = std::cmp::max(
+                minimum_spawn_rate,
+                initial_spawn_rate.saturating_sub(self.tick / speed_up_rate),
+            );
+            if self.player.health > 0 {
+                text!("spawn rate: {}", spawn_rate; x = 4, y = 22, font = "small");
+            }
+            if self.tick % spawn_rate == 0 && self.enemies.len() < 24 {
+                self.enemies.push(match rand() % 8 {
+                    0 => Enemy::tank(),
+                    1 => Enemy::tank(),
+                    2 => Enemy::shooter(),
+                    3 => Enemy::shooter(),
+                    4 => Enemy::meteor(),
+                    5 => Enemy::zipper(),
+                    6 => Enemy::turret(),
+                    7 => Enemy::turret(),
+                    _ => unreachable!(),
+                });
+            }
+        }
+        // Handle player picking up power-ups
+        self.powerups.retain(|powerup| {
+            if check_collision(
+                powerup.x,
+                powerup.y,
+                powerup.width,
+                powerup.height,
+                self.player.x,
+                self.player.y,
+                self.player.width,
+                self.player.height,
+            ) {
+                match powerup.effect {
+                    PowerupEffect::Heal => {
+                        self.player.health = (self.player.health + 1).min(self.player.max_health);
+                        self.player.skill_points += 1;
+                        self.notifications.push("+1 Health".to_string());
+                    }
+                    PowerupEffect::MaxHealthUp => {
+                        self.player.max_health = (self.player.max_health + 1).min(10);
+                        self.player.health = self.player.max_health;
+                        self.player.skill_points += 1;
+                        self.notifications.push("Max Health +1".to_string());
+                    }
+                    PowerupEffect::SpeedBoost => {
+                        self.player.speed *= 1.1;
+                        self.player.skill_points += 1;
+                        self.notifications.push("1.1x Speed Boost".to_string());
+                    }
+                    PowerupEffect::DamageBoost(projectile_type) => {
+                        if self.player.projectile_type == projectile_type {
+                            self.notifications
+                                .push(format!("+1 {projectile_type:?} Damage"));
+                            self.player.skill_points += 1;
+                            self.player.projectile_damage =
+                                (self.player.projectile_damage + 1).min(2);
+                        }
                     }
                 }
+                false // Remove the power-up after it's picked up
+            } else {
+                true
             }
-            false // Remove the power-up after it's picked up
-        } else {
-            true
-        }
-    });
+        });
 
-    // Update projectiles and check for collisions with enemies
-    let mut splashes = vec![];
-    state.projectiles.retain(|projectile| {
-        let mut projectile_active = true;
-        if projectile.projectile_owner != ProjectileOwner::Player {
-            return projectile_active;
-        }
-        state.enemies.retain_mut(|enemy| {
-            let did_collide = check_collision(
-                projectile.x, projectile.y, projectile.width, projectile.height,
-                enemy.x, enemy.y, enemy.width, enemy.height
-            );
-            if did_collide {
-                enemy.health = enemy.health.saturating_sub(projectile.damage);
-                projectile_active = false; // Remove projectile on collision
-                if enemy.health == 0 {
-                    state.score += 1;
-                    state.player.skill_points += enemy.points; // To ensure this triggers only once per threshold
-                    if rand() % 10 == 0 {
-                        state.powerups.push(Powerup {
-                            x: enemy.x,
-                            y: enemy.y,
-                            width: 8,
-                            height: 8,
-                            effect: PowerupEffect::SpeedBoost, // TODO: maybe randomize
-                            movement: PowerupMovement::Floating(0.1),
-                        });
-                        // Spawn additional power-up when player reaches skill point threshold
-                        if state.player.skill_points > 500 { // Adjust the skill point threshold
-                            state.powerups.push(Powerup {
-                                x: (rand() % screen_w) as f32,
-                                y: (rand() % screen_h) as f32,
+        // Update projectiles and check for collisions with enemies
+        let mut splashes = vec![];
+        self.projectiles.retain(|projectile| {
+            let mut projectile_active = true;
+            if projectile.projectile_owner != ProjectileOwner::Player {
+                return projectile_active;
+            }
+            self.enemies.retain_mut(|enemy| {
+                let did_collide = check_collision(
+                    projectile.x,
+                    projectile.y,
+                    projectile.width,
+                    projectile.height,
+                    enemy.x,
+                    enemy.y,
+                    enemy.width,
+                    enemy.height,
+                );
+                if did_collide {
+                    enemy.health = enemy.health.saturating_sub(projectile.damage);
+                    projectile_active = false; // Remove projectile on collision
+                    if enemy.health == 0 {
+                        self.score += 1;
+                        self.player.skill_points += enemy.points; // To ensure this triggers only once per threshold
+                        if rand() % 10 == 0 {
+                            self.powerups.push(Powerup {
+                                x: enemy.x,
+                                y: enemy.y,
                                 width: 8,
                                 height: 8,
-                                effect: PowerupEffect::DamageBoost(ProjectileType::Splatter), // TODO: maybe randomize
-                                movement: PowerupMovement::Floating(0.5),
+                                effect: PowerupEffect::SpeedBoost, // TODO: maybe randomize
+                                movement: PowerupMovement::Floating(0.1),
                             });
+                            // Spawn additional power-up when player reaches skill point threshold
+                            if self.player.skill_points > 500 {
+                                // Adjust the skill point threshold
+                                self.powerups.push(Powerup {
+                                    x: (rand() % screen_w) as f32,
+                                    y: (rand() % screen_h) as f32,
+                                    width: 8,
+                                    height: 8,
+                                    effect: PowerupEffect::DamageBoost(ProjectileType::Splatter), // TODO: maybe randomize
+                                    movement: PowerupMovement::Floating(0.5),
+                                });
+                            }
+                        }
+                    }
+                    // Additional behavior based on projectile type
+                    match projectile.projectile_type {
+                        ProjectileType::Basic => {
+                            // ...
+                        }
+                        ProjectileType::Splatter => {
+                            // Splatter creates fragments on impact, affecting a wider area
+                            let splash_angles = [45.0, 135.0, 225.0, 315.0]; // Diagonal angles
+                            for &angle in splash_angles.iter() {
+                                splashes.push(Projectile {
+                                    x: projectile.x,
+                                    y: projectile.y,
+                                    width: projectile.width,
+                                    height: projectile.height,
+                                    velocity: projectile.velocity / 2.0, // Reduced velocity for splash projectiles
+                                    angle,
+                                    damage: projectile.damage / 2, // Reduced damage for splash projectiles
+                                    projectile_type: ProjectileType::Fragment,
+                                    projectile_owner: ProjectileOwner::Player,
+                                    ttl: Some(10),
+                                });
+                            }
+                        }
+                        ProjectileType::Fragment => {
+                            // ...
+                        }
+                        ProjectileType::Laser => {
+                            // ...
+                        }
+                        ProjectileType::Bomb => {
+                            // ...
                         }
                     }
                 }
-                // Additional behavior based on projectile type
-                match projectile.projectile_type {
-                    ProjectileType::Basic => {
-                        // ...
-                    }
-                    ProjectileType::Splatter => {
-                        // Splatter creates fragments on impact, affecting a wider area
-                        let splash_angles = [45.0, 135.0, 225.0, 315.0];  // Diagonal angles
-                        for &angle in splash_angles.iter() {
-                            splashes.push(Projectile {
-                                x: projectile.x,
-                                y: projectile.y,
-                                width: projectile.width,
-                                height: projectile.height,
-                                velocity: projectile.velocity / 2.0,  // Reduced velocity for splash projectiles
-                                angle,
-                                damage: projectile.damage / 2,  // Reduced damage for splash projectiles
-                                projectile_type: ProjectileType::Fragment,
-                                projectile_owner: ProjectileOwner::Player,
-                                ttl: Some(10)
-                            });
-                        }
-                    },
-                    ProjectileType::Fragment => {
-                        // ...
-                    },
-                    ProjectileType::Laser => {
-                        // ...
-                    },
-                    ProjectileType::Bomb => {
-                        // ...
-                    },
-                }
-            }
-            enemy.health > 0
+                enemy.health > 0
+            });
+            projectile_active
         });
-        projectile_active
-    });
 
-    // Handle collisions between enemy projectiles and the player
-    state.projectiles.retain(|projectile| {
-        let mut projectile_active = true;
-        if projectile.projectile_owner != ProjectileOwner::Enemy {
-            return projectile_active;
+        // Handle collisions between enemy projectiles and the player
+        self.projectiles.retain(|projectile| {
+            let mut projectile_active = true;
+            if projectile.projectile_owner != ProjectileOwner::Enemy {
+                return projectile_active;
+            }
+            let did_collide = check_collision(
+                projectile.x,
+                projectile.y,
+                projectile.width,
+                projectile.height,
+                self.player.x,
+                self.player.y,
+                self.player.width,
+                self.player.height,
+            );
+            if did_collide {
+                if self.player.health != 0 {
+                    let prev_hp = self.player.health;
+                    self.player.health = self.player.health.saturating_sub(projectile.damage);
+                    // hit timer is longer on final hit
+                    self.hit_timer = if prev_hp > 0 && self.player.health == 0 {
+                        20
+                    } else {
+                        10
+                    };
+                    projectile_active = false // Remove the projectile on collision
+                }
+            }
+
+            projectile_active
+        });
+
+        // Add projectile splashes
+        for projectile in splashes {
+            self.projectiles.push(projectile);
         }
-        let did_collide = check_collision(
-            projectile.x, projectile.y, projectile.width, projectile.height,
-            state.player.x, state.player.y, state.player.width, state.player.height
-        );
-        if did_collide {
-            if state.player.health != 0{
-                let prev_hp = state.player.health;
-                state.player.health = state.player.health.saturating_sub(projectile.damage);
-                // hit timer is longer on final hit
-                state.hit_timer = if prev_hp > 0 && state.player.health == 0 { 20 } else { 10 };
-                projectile_active = false // Remove the projectile on collision
+
+        // Update projectiles
+        for projectile in &mut self.projectiles {
+            // projectile.y -= projectile.velocity;
+            let radian_angle = projectile.angle.to_radians();
+            projectile.x += projectile.velocity * radian_angle.cos();
+            projectile.y += projectile.velocity * radian_angle.sin();
+
+            if let Some(ttl) = &mut projectile.ttl {
+                *ttl = ttl.saturating_sub(1);
             }
         }
 
-        projectile_active
-    });
+        // Remove expired and out-of-bounds projectiles
+        self.projectiles.retain(|projectile| {
+            projectile.ttl.map_or(true, |ttl| ttl > 0)
+                || projectile.y < -(projectile.height as f32)
+                || projectile.x < -(projectile.width as f32)
+                || projectile.x > screen_w as f32
+                || projectile.y > screen_h as f32
+        });
 
+        // Check enemy x player collisions
+        self.enemies.retain(|enemy| {
+            let did_collide = check_collision(
+                self.player.x,
+                self.player.y,
+                self.player.width,
+                self.player.height,
+                enemy.x,
+                enemy.y,
+                enemy.width,
+                enemy.height,
+            );
+            if did_collide {
+                // Collision detected, reduce player health
+                self.player.health = self.player.health.saturating_sub(1); // Adjust damage as needed
+                                                                           // return false;
+            }
+            return enemy.y < screen_h as f32;
+        });
 
-    // Add projectile splashes
-    for projectile in splashes {
-        state.projectiles.push(projectile);
+        for enemy in &mut self.enemies {
+            match enemy.strategy {
+                EnemyStrategy::TargetPlayer(intensity, speed, size) => {
+                    // Logic for attacking with specified intensity
+                    enemy.y += enemy.speed;
+                    if rand() % (250 / intensity as u32) == 0 {
+                        // Calculate angle from enemy to player
+                        let angle = ((self.player.y - enemy.y).atan2(self.player.x - enemy.x)
+                            * 180.0)
+                            / std::f32::consts::PI;
+
+                        // Create and shoot projectiles from enemy towards the player
+                        self.projectiles.push(Projectile {
+                            x: enemy.x + (enemy.width as f32 * 0.5) - (size as f32 * 0.5),
+                            y: enemy.y + (enemy.height as f32),
+                            width: size,
+                            height: size,
+                            velocity: speed,
+                            angle: angle,
+                            // damage: intensity as u32, // Damage based on attack intensity
+                            damage: 1,
+                            projectile_type: ProjectileType::Laser, // Assuming enemy uses Laser
+                            projectile_owner: ProjectileOwner::Enemy,
+                            ttl: None,
+                        });
+                    }
+                }
+                EnemyStrategy::ShootDown(intensity, speed, size) => {
+                    // Logic for attacking with specified intensity
+                    enemy.y += enemy.speed;
+                    if rand() % (250 / intensity as u32) == 0 {
+                        // Create and shoot projectiles from enemy towards the player
+                        self.projectiles.push(Projectile {
+                            x: enemy.x + (enemy.width as f32 * 0.5) - (size as f32 * 0.5),
+                            y: enemy.y + (enemy.height as f32),
+                            width: size,
+                            height: size,
+                            velocity: speed,
+                            angle: 90.0,
+                            // damage: intensity as u32, // Damage based on attack intensity
+                            damage: 1,
+                            projectile_type: ProjectileType::Laser, // Assuming enemy uses Laser
+                            projectile_owner: ProjectileOwner::Enemy,
+                            ttl: None,
+                        });
+                    }
+                }
+                EnemyStrategy::MoveDown => {
+                    enemy.y += enemy.speed;
+                }
+                EnemyStrategy::RandomZigZag(angle) => {
+                    // Logic for dodging attacks, using angle to determine movement
+                    enemy.x += enemy.speed * enemy.angle.cos();
+                    enemy.y += enemy.speed;
+                    // Reverse direction when heading out of bounds
+                    if enemy.x < 0.0 || enemy.x > screen_w as f32 {
+                        enemy.angle = std::f32::consts::PI - enemy.angle;
+                    }
+                    // 5% chance to randomly change angle
+                    else if rand() % 20 == 0 {
+                        enemy.angle += std::f32::consts::PI / angle; // Change angle
+                    }
+                }
+            }
+        }
+
+        // Update power-up positions based on their movement patterns
+        for powerup in &mut self.powerups {
+            match powerup.movement {
+                PowerupMovement::Floating(speed) => {
+                    powerup.y += speed;
+                    // Optionally, reverse the direction if it reaches the screen bounds
+                    if powerup.y <= 0.0 || powerup.y >= screen_h as f32 {
+                        powerup.movement = PowerupMovement::Floating(-speed);
+                    }
+                }
+                PowerupMovement::Drifting(speed) => {
+                    powerup.x += speed;
+                    // Optionally, reverse the direction if it reaches the screen bounds
+                    if powerup.x <= 0.0 || powerup.x >= screen_w as f32 {
+                        powerup.movement = PowerupMovement::Drifting(-speed);
+                    }
+                }
+                PowerupMovement::Static => {
+                    // Static powerups do not move
+                }
+            }
+        }
+
+        // Enable skills
+        if self.score > 100 && !self.player.skills.speed_boost {
+            self.player.skills.speed_boost = true;
+        }
+        if self.score > 200 && !self.player.skills.double_damage {
+            self.player.skills.double_damage = true;
+        }
+
+        // Notifications timer
+        if self.notifications.len() > 0 {
+            self.notification_timer += 1;
+            if self.notification_timer >= 120 - 1 {
+                self.notification_timer = 0;
+                let _ = self.notifications.remove(0);
+            }
+        }
+
+        // hit timer
+        self.hit_timer = self.hit_timer.saturating_sub(1);
+
+        self.tick += 1;
     }
 
-    // Update projectiles
-    for projectile in &mut state.projectiles {
-        // projectile.y -= projectile.velocity;
-        let radian_angle = projectile.angle.to_radians();
-        projectile.x += projectile.velocity * radian_angle.cos();
-        projectile.y += projectile.velocity * radian_angle.sin();
+    // Define a function for rendering game elements
+    fn draw_game_elements(self: &GameState) {
+        let (screen_w, screen_h) = resolution();
 
-        if let Some(ttl) = &mut projectile.ttl {
-            *ttl = ttl.saturating_sub(1);
+        if self.hit_timer > 0 {
+            camera::move_xy(rand() as i32 % 3 - 1, rand() as i32 % 3 - 1);
+        } else {
+            camera::reset();
+        }
+
+        // Draw moving parallax stars in the background
+        Self::draw_stars(self, screen_w, screen_h);
+
+        // Drawing the character with customization
+        if self.player.health > 0 {
+            draw_player(&self.player);
+        }
+
+        // Draw enemies
+        for enemy in &self.enemies {
+            draw_enemy(enemy);
+        }
+
+        // Draw projectiles
+        for projectile in &self.projectiles {
+            draw_projectile(projectile);
+        }
+
+        // Draw powerups
+        for powerup in &self.powerups {
+            draw_powerup(powerup, self.tick);
+        }
+
+        // Reset camera
+        //camera::reset();
+
+        // Render notifications
+        draw_notifications(self, screen_w, screen_h);
+
+        // Game over text
+        if self.player.health == 0 {
+            draw_game_over(self, screen_w, screen_h);
+        }
+
+        // Draw game HUD
+        draw_hud(self, screen_w);
+    }
+
+    fn draw_stars(self: &GameState, screen_w: u32, screen_h: u32) {
+        // Define star layers with different speeds
+        let star_layers = [
+            (54321, 1, 0.15, 10),
+            (12345, 1, 0.25, 10),
+            (67890, 2, 0.35, 10),
+        ];
+
+        for &(seed, size, speed, count) in star_layers.iter() {
+            for i in 0..count {
+                let rand_x = rand_with_seed(seed + i + self.tick / 10) % screen_w;
+                let rand_y = (rand_with_seed(seed + i + self.tick / 10) / screen_w) % screen_h;
+
+                // Adjust position slightly based on player movement
+                let adjust_x = self.player.x * speed / -5.0;
+                let adjust_y = self.player.y * speed / -5.0;
+
+                let x = rand_x as i32 + adjust_x as i32;
+                let y = (self.tick as f32 * speed) as i32 + rand_y as i32 + adjust_y as i32;
+
+                // Draw the star
+                circ!(
+                    x = x % screen_w as i32,
+                    y = y % screen_h as i32,
+                    d = size,
+                    color = 0xFFFFFF44
+                ); // Adjust star size and color if needed
+            }
         }
     }
-
-    // Remove expired and out-of-bounds projectiles
-    state.projectiles.retain(|projectile| {
-        projectile.ttl.map_or(true, |ttl| ttl > 0) ||
-        projectile.y < -(projectile.height as f32) ||
-        projectile.x < -(projectile.width as f32) ||
-        projectile.x > screen_w as f32 ||
-        projectile.y > screen_h as f32
-    });
-
-    // Check enemy x player collisions
-    state.enemies.retain(|enemy| {
-        let did_collide = check_collision(
-            state.player.x, state.player.y, state.player.width, state.player.height,
-            enemy.x, enemy.y, enemy.width, enemy.height
-        );
-        if did_collide {
-            // Collision detected, reduce player health
-            state.player.health = state.player.health.saturating_sub(1); // Adjust damage as needed
-            // return false;
-        }
-        return enemy.y < screen_h as f32;
-    });
-
-    for enemy in &mut state.enemies {
-        match enemy.strategy {
-            EnemyStrategy::TargetPlayer(intensity, speed, size) => {
-                // Logic for attacking with specified intensity
-                enemy.y += enemy.speed;
-                if rand() % (250 / intensity as u32) == 0 {
-                    // Calculate angle from enemy to player
-                    let angle = ((state.player.y - enemy.y).atan2(state.player.x - enemy.x) * 180.0) / std::f32::consts::PI;
-
-                    // Create and shoot projectiles from enemy towards the player
-                    state.projectiles.push(Projectile {
-                        x: enemy.x + (enemy.width as f32 * 0.5) - (size as f32 * 0.5),
-                        y: enemy.y + (enemy.height as f32),
-                        width: size,
-                        height: size,
-                        velocity: speed,
-                        angle: angle,
-                        // damage: intensity as u32, // Damage based on attack intensity
-                        damage: 1,
-                        projectile_type: ProjectileType::Laser, // Assuming enemy uses Laser
-                        projectile_owner: ProjectileOwner::Enemy,
-                        ttl: None,
-                    });
-                }
-            },
-            EnemyStrategy::ShootDown(intensity, speed, size) => {
-                // Logic for attacking with specified intensity
-                enemy.y += enemy.speed;
-                if rand() % (250 / intensity as u32) == 0 {
-                    // Create and shoot projectiles from enemy towards the player
-                    state.projectiles.push(Projectile {
-                        x: enemy.x + (enemy.width as f32 * 0.5) - (size as f32 * 0.5),
-                        y: enemy.y + (enemy.height as f32),
-                        width: size,
-                        height: size,
-                        velocity: speed,
-                        angle: 90.0,
-                        // damage: intensity as u32, // Damage based on attack intensity
-                        damage: 1,
-                        projectile_type: ProjectileType::Laser, // Assuming enemy uses Laser
-                        projectile_owner: ProjectileOwner::Enemy,
-                        ttl: None,
-                    });
-                }
-            },
-            EnemyStrategy::MoveDown => {
-                enemy.y += enemy.speed;
-            },
-            EnemyStrategy::RandomZigZag(angle) => {
-                // Logic for dodging attacks, using angle to determine movement
-                enemy.x += enemy.speed * enemy.angle.cos();
-                enemy.y += enemy.speed;
-                // Reverse direction when heading out of bounds
-                if enemy.x < 0.0 || enemy.x > screen_w as f32 {
-                    enemy.angle = std::f32::consts::PI - enemy.angle;
-                }
-                // 5% chance to randomly change angle
-                else if rand() % 20 == 0 {
-                    enemy.angle += std::f32::consts::PI / angle; // Change angle
-                }
-            },
-        }
-    }
-
-    // Update power-up positions based on their movement patterns
-     for powerup in &mut state.powerups {
-        match powerup.movement {
-            PowerupMovement::Floating(speed) => {
-                powerup.y += speed;
-                // Optionally, reverse the direction if it reaches the screen bounds
-                if powerup.y <= 0.0 || powerup.y >= screen_h as f32 {
-                    powerup.movement = PowerupMovement::Floating(-speed);
-                }
-            },
-            PowerupMovement::Drifting(speed) => {
-                powerup.x += speed;
-                // Optionally, reverse the direction if it reaches the screen bounds
-                if powerup.x <= 0.0 || powerup.x >= screen_w as f32 {
-                    powerup.movement = PowerupMovement::Drifting(-speed);
-                }
-            },
-            PowerupMovement::Static => {
-                // Static powerups do not move
-            },
-        }
-    }
-
-
-    // Enable skills
-    if state.score > 100 && !state.player.skills.speed_boost {
-        state.player.skills.speed_boost = true;
-    }
-    if state.score > 200 && !state.player.skills.double_damage {
-        state.player.skills.double_damage = true;
-    }
-
-    // Notifications timer
-    if state.notifications.len() > 0 {
-        state.notification_timer += 1;
-        if state.notification_timer >= 120 - 1 {
-            state.notification_timer = 0;
-            let _ = state.notifications.remove(0);
-        }
-    }
-
-    // hit timer
-    state.hit_timer = state.hit_timer.saturating_sub(1);
-
-    state.tick += 1;
-    state.save();
 }
-
-// Define a function for rendering game elements
-fn draw_game_elements(state: &GameState) {
-    let (screen_w, screen_h) = resolution();
-
-    if state.hit_timer > 0 {
-        camera::move_xy(rand() as i32 % 3 - 1, rand() as i32 % 3 - 1);
-    } else {
-        camera::reset();
-    }
-
-    // Draw moving parallax stars in the background
-    draw_stars(state, screen_w, screen_h);
-
-    // Drawing the character with customization
-    if state.player.health > 0 {
-        draw_player(&state.player);
-    }
-
-    // Draw enemies
-    for enemy in &state.enemies {
-        draw_enemy(enemy);
-    }
-
-    // Draw projectiles
-    for projectile in &state.projectiles {
-        draw_projectile(projectile);
-    }
-
-    // Draw powerups
-    for powerup in &state.powerups {
-        draw_powerup(powerup, state.tick);
-    }
-
-    // Reset camera
-    //camera::reset();
-
-    // Render notifications
-    draw_notifications(state, screen_w, screen_h);
-
-    // Game over text
-    if state.player.health == 0 {
-        draw_game_over(state, screen_w, screen_h);
-    }
-
-    // Draw game HUD
-    draw_hud(state, screen_w);
-}
-
-fn draw_stars(state: &GameState, screen_w: u32, screen_h: u32) {
-    // Define star layers with different speeds
-    let star_layers = [
-        (54321, 1, 0.15, 10),
-        (12345, 1, 0.25, 10),
-        (67890, 2, 0.35, 10),
-    ];
-
-    for &(seed, size, speed, count) in star_layers.iter() {
-        for i in 0..count {
-            let rand_x = rand_with_seed(seed + i + state.tick / 10) % screen_w;
-            let rand_y = (rand_with_seed(seed + i + state.tick / 10) / screen_w) % screen_h;
-
-            // Adjust position slightly based on player movement
-            let adjust_x = state.player.x * speed / -5.0;
-            let adjust_y = state.player.y * speed / -5.0;
-
-            let x = rand_x as i32 + adjust_x as i32;
-            let y = (state.tick as f32 * speed) as i32 + rand_y as i32 + adjust_y as i32;
-
-            // Draw the star
-            circ!(
-                x = x % screen_w as i32,
-                y = y % screen_h as i32,
-                d = size,
-                color = 0xFFFFFF44
-            ); // Adjust star size and color if needed
-        }
-    }
-});
 
 fn draw_player(player: &Player) {
     rect!(

--- a/space-shooter/src/lib.rs
+++ b/space-shooter/src/lib.rs
@@ -81,7 +81,7 @@ impl GameState {
             // Restart
             if self.hit_timer == 0 && gamepad(0).start.just_pressed() || gamepad(0).a.just_pressed()
             {
-                self = &mut GameState::new(); // running into an error here I cant solve
+                self = GameState::new(); // running into an error here I cant solve
             }
         } else {
             // Player movement handling

--- a/space-shooter/src/lib.rs
+++ b/space-shooter/src/lib.rs
@@ -81,7 +81,7 @@ impl GameState {
             // Restart
             if self.hit_timer == 0 && gamepad(0).start.just_pressed() || gamepad(0).a.just_pressed()
             {
-                self = GameState::new(); // running into an error here I cant solve
+                GameState::new(); // running into an error here I cant solve
             }
         } else {
             // Player movement handling

--- a/tanks/Cargo.toml
+++ b/tanks/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 turbo = { version = "^3.0.0", package = "turbo-genesis-sdk" }
+turbo-genesis-sdk = "3.1.1"
 
 [lib]
 crate-type = ["cdylib"]

--- a/tanks/Cargo.toml
+++ b/tanks/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-turbo = { version = "^3.0.0", package = "turbo-genesis-sdk" }
+turbo = { version = "^3.1.0", package = "turbo-genesis-sdk" }
 turbo-genesis-sdk = "3.1.1"
 
 [lib]

--- a/tanks/Cargo.toml
+++ b/tanks/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 turbo = { version = "^3.1.0", package = "turbo-genesis-sdk" }
-turbo-genesis-sdk = "3.1.1"
 
 [lib]
 crate-type = ["cdylib"]

--- a/tanks/src/lib.rs
+++ b/tanks/src/lib.rs
@@ -44,13 +44,13 @@ impl GameState {
         }
     }
     fn update(&mut self) {
-        let mut tanks = state.tanks.iter_mut();
+        let mut tanks = self.tanks.iter_mut();
         let mut tank1 = tanks.next().unwrap();
         let mut tank2 = tanks.next().unwrap();
 
         // Draw stuff
         rect!(w = 256, h = 144, color = 0x222222ff);
-        draw_blocks(&state.blocks);
+        draw_blocks(&self.blocks);
         draw_tank(&tank1);
         draw_tank(&tank2);
 
@@ -58,16 +58,16 @@ impl GameState {
         let gp1 = gamepad(0);
         let gp2 = gamepad(1);
 
-        if let Some(winner) = &state.winner {
+        if let Some(winner) = &self.winner {
             // Show winner message
             text!("WINNER {:#?}", winner; font = "large");
         } else {
             // Update tanks and check for missile collisions
-            update_tank(&gp1, &mut tank1, &state.blocks);
-            update_tank(&gp2, &mut tank2, &state.blocks);
+            update_tank(&gp1, &mut tank1, &self.blocks);
+            update_tank(&gp2, &mut tank2, &self.blocks);
             let tank1_got_hit = did_hit_missile(&tank1, &tank2.missiles);
             let tank2_got_hit = did_hit_missile(&tank2, &tank1.missiles);
-            state.winner = match (tank1_got_hit, tank2_got_hit) {
+            self.winner = match (tank1_got_hit, tank2_got_hit) {
                 (false, false) => None,
                 (true, true) => Some(Winner::Draw),
                 (true, false) => Some(Winner::P2),

--- a/tanks/src/lib.rs
+++ b/tanks/src/lib.rs
@@ -1,8 +1,8 @@
 use turbo::prelude::*;
-use turbo_genesis_sdk::prelude::*;
 
+#[derive(BorshDeserialize, BorshSerialize)]
 #[turbo::game]
-#[derive(Debug, Clone, PartialEq, BorshDeserialize, BorshSerialize)]
+
 struct GameState {
     winner: Option<Winner>,
     tanks: Vec<Tank>,
@@ -222,6 +222,7 @@ fn create_mirrored_blocks(positions: &[(f32, f32, u32, u32)]) -> Vec<Block> {
     mirrored_blocks
 }
 
+#[derive(PartialEq, Clone, Debug, BorshDeserialize, BorshSerialize)]
 enum Winner {
     P1,
     P2,
@@ -244,7 +245,7 @@ impl Rect {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, BorshDeserialize, BorshSerialize)]
+#[derive(BorshDeserialize, BorshSerialize)]
 
 struct Tank {
     color: u32,
@@ -265,7 +266,7 @@ impl Tank {
         }
     }
 }
-
+#[derive(BorshDeserialize, BorshSerialize)]
 struct Missile {
     x: f32,
     y: f32,
@@ -284,6 +285,7 @@ impl Missile {
     }
 }
 
+#[derive(BorshDeserialize, BorshSerialize)]
 struct Block {
     x: f32,
     y: f32,

--- a/tanks/src/lib.rs
+++ b/tanks/src/lib.rs
@@ -1,52 +1,38 @@
-turbo::init! {
-    struct GameState {
-        winner: Option<enum Winner {
-            P1,
-            P2,
-            Draw,
-        }>,
-        tanks: Vec<struct Tank {
-            color: u32,
-            x: f32,
-            y: f32,
-            vel: f32,
-            rot: f32,
-            missiles: Vec<struct Missile {
-                x: f32,
-                y: f32,
-                vel: f32,
-                rot: f32,
-            }>
-        }>,
-        blocks: Vec<struct Block {
-            x: f32,
-            y: f32,
-            width: u32,
-            height: u32,
-        }>
-    } = {
+use turbo::prelude::*;
+use turbo_genesis_sdk::prelude::*;
+
+#[turbo::game]
+#[derive(Debug, Clone, PartialEq, BorshDeserialize, BorshSerialize)]
+struct GameState {
+    winner: Option<Winner>,
+    tanks: Vec<Tank>,
+    blocks: Vec<Block>,
+}
+
+impl GameState {
+    fn new() -> Self {
         let (w, h) = resolution();
         let w = w as f32;
-        let h = h as f32;        
-                Self {
+        let h = h as f32;
+        Self {
             winner: None,
             tanks: vec![
                 Tank {
                     color: 0xffff00ff,
                     x: 32.,
-                    y: (h/2.),
+                    y: (h / 2.),
                     vel: 0.,
                     rot: 0.,
-                    missiles: vec![]
+                    missiles: vec![],
                 },
                 Tank {
                     color: 0xff00ffff,
                     x: w - 32.,
-                    y: (h/2.),
+                    y: (h / 2.),
                     vel: 0.,
                     rot: std::f32::consts::PI, // 180deg in radians
-                    missiles: vec![]
-                }
+                    missiles: vec![],
+                },
             ],
             blocks: create_mirrored_blocks(&[
                 (32.0, 0.0, 16, 16),
@@ -54,47 +40,41 @@ turbo::init! {
                 (72.0, 40.0, 16, 64),
                 (128.0, 112.0, 8, 32),
                 (32.0, 128.0, 16, 16),
-            ])
+            ]),
         }
     }
-}
+    fn update(&mut self) {
+        let mut tanks = state.tanks.iter_mut();
+        let mut tank1 = tanks.next().unwrap();
+        let mut tank2 = tanks.next().unwrap();
 
-turbo::go! {
-    // Load game state
-    let mut state = GameState::load();
-    let mut tanks = state.tanks.iter_mut();
-    let mut tank1 = tanks.next().unwrap();
-    let mut tank2 = tanks.next().unwrap();
+        // Draw stuff
+        rect!(w = 256, h = 144, color = 0x222222ff);
+        draw_blocks(&state.blocks);
+        draw_tank(&tank1);
+        draw_tank(&tank2);
 
-    // Draw stuff
-    rect!(w = 256,h = 144, color = 0x222222ff);
-    draw_blocks(&state.blocks);
-    draw_tank(&tank1);
-    draw_tank(&tank2);
+        // Update tank positions, rotations, and firing
+        let gp1 = gamepad(0);
+        let gp2 = gamepad(1);
 
-    // Update tank positions, rotations, and firing
-    let gp1 = gamepad(0);
-    let gp2 = gamepad(1);
-
-    if let Some(winner) = &state.winner {
-        // Show winner message
-        text!("WINNER {:#?}", winner; font = "large");
-    } else {
-        // Update tanks and check for missile collisions
-        update_tank(&gp1, &mut tank1, &state.blocks);
-        update_tank(&gp2, &mut tank2, &state.blocks);
-        let tank1_got_hit = did_hit_missile(tank1, &tank2.missiles);
-        let tank2_got_hit = did_hit_missile(tank2, &tank1.missiles);
-        state.winner = match (tank1_got_hit, tank2_got_hit) {
-            (false, false) => None,
-            (true, true) => Some(Winner::Draw),
-            (true, false) => Some(Winner::P2),
-            (false, true) => Some(Winner::P1),
-        }
-    };
-
-    // Save the game state
-    state.save();
+        if let Some(winner) = &state.winner {
+            // Show winner message
+            text!("WINNER {:#?}", winner; font = "large");
+        } else {
+            // Update tanks and check for missile collisions
+            update_tank(&gp1, &mut tank1, &state.blocks);
+            update_tank(&gp2, &mut tank2, &state.blocks);
+            let tank1_got_hit = did_hit_missile(&tank1, &tank2.missiles);
+            let tank2_got_hit = did_hit_missile(&tank2, &tank1.missiles);
+            state.winner = match (tank1_got_hit, tank2_got_hit) {
+                (false, false) => None,
+                (true, true) => Some(Winner::Draw),
+                (true, false) => Some(Winner::P2),
+                (false, true) => Some(Winner::P1),
+            }
+        };
+    }
 }
 
 fn did_hit_missile(tank: &Tank, missiles: &[Missile]) -> bool {
@@ -242,6 +222,12 @@ fn create_mirrored_blocks(positions: &[(f32, f32, u32, u32)]) -> Vec<Block> {
     mirrored_blocks
 }
 
+enum Winner {
+    P1,
+    P2,
+    Draw,
+}
+
 struct Rect {
     width: u32,
     height: u32,
@@ -258,6 +244,17 @@ impl Rect {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, BorshDeserialize, BorshSerialize)]
+
+struct Tank {
+    color: u32,
+    x: f32,
+    y: f32,
+    vel: f32,
+    rot: f32,
+    missiles: Vec<Missile>,
+}
+
 impl Tank {
     fn hitbox(&self) -> Rect {
         Rect {
@@ -269,6 +266,13 @@ impl Tank {
     }
 }
 
+struct Missile {
+    x: f32,
+    y: f32,
+    vel: f32,
+    rot: f32,
+}
+
 impl Missile {
     fn hitbox(&self) -> Rect {
         Rect {
@@ -278,6 +282,13 @@ impl Missile {
             height: 6,
         }
     }
+}
+
+struct Block {
+    x: f32,
+    y: f32,
+    width: u32,
+    height: u32,
 }
 
 impl Block {


### PR DESCRIPTION
This pull request
- transfers over all game demos to the new procedural macro:
`#[turbo::game]`

What did this entail?

- update version of turbo in Cargo.toml file
- all files should import `use turbo::prelude::*;`
- any references to `state `in turbo::go should now be `self`
-  game state pulled out of turbo init. **Note that you can no longer destructure inline.** 

```
struct GameState {
//info here
}
```

- change turbo init and go functions to the following new format:
```
   
impl GameState{
    fn new()->Self{
                   // former turbo init info goes here.
     } 
     fn update(&mut self){
                  // former turbo go info goes here. remove save and load functions. 
      }
}

```